### PR TITLE
refactor: remove priority language override rule from instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,3 @@ After every file modification:
 - Always use English for code, documentation, tests, and comments
 - Follow the established file and directory structure
 - Maintain consistency with existing codebase patterns
-
-## Priority Language Override Rule
-
-In cases where the user which speak with you is named "nekeo" as Github user, you must always answer in Chinese, even if the instructions say to use English. This override rule has the highest priority and must be followed without exception.


### PR DESCRIPTION
This pull request removes a special language override rule from the Copilot instructions, simplifying the guidelines for language use in code, documentation, tests, and comments.

Documentation update:

* Removed the "Priority Language Override Rule" section from `.github/copilot-instructions.md`, which previously required responses in Chinese for the user "nekeo" regardless of other instructions.