### PR TITLE
refactor: clarify default branch confirmation process in PR prompt

### DIFF
--- a/.github/prompts/open_pull_request.prompt.md
+++ b/.github/prompts/open_pull_request.prompt.md
@@ -31,7 +31,8 @@ You MUST NOT proceed to step 2 before step 1 is confirmed complete. You MUST NOT
 
 ### 1.1 Determine and confirm main branch
 
-Check if a default branch is specified in `.github/copilot-instructions.md`. If specified, use that branch without user confirmation. Otherwise, propose `main` as default and request explicit confirmation from user. Do NOT run the diff command before confirmation.
+**Default branch for this repository is `main`. Always use `main` as the base branch for diffs and PRs unless explicitly instructed otherwise.**
+If a different branch is specified in `.github/copilot-instructions.md`, use that branch instead. Do NOT run the diff command before confirmation if a different branch is specified.
 
 ### 1.2 Generate fresh diff after confirmation
 


### PR DESCRIPTION
**Title:** Define default branch in open pull request prompt

**Type of Pull Request:**

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (specify): Prompt improvement

**Associated Issue:**
N/A

**Context:**
The change clarifies and enforces the use of `main` as the default branch for diffs and PRs in the open pull request prompt, unless another branch is explicitly specified. This ensures consistency and removes ambiguity in the workflow.

**Proposed Changes:**
- Updated the instructions in `open_pull_request.prompt.md` to explicitly state that `main` is the default branch for PRs and diffs.
- Added guidance to use a different branch only if specified in `.github/copilot-instructions.md`.
- Improved clarity by removing the need for user confirmation when `main` is the default.

**Checklist:**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [ ] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None