### PR TITLE
feat(db): add Dockerfile for PostgreSQL setup

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:17-alpine
+
+EXPOSE 5432

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,40 @@
+# PostgreSQL Dockerfile Usage
+
+This directory contains a custom `Dockerfile` for running a PostgreSQL database for the SlotFinder project.
+
+## How to Use
+
+1. **Build the Docker image**
+
+   From the `db/` directory:
+
+   ```bash
+   docker build -t slotfinder-postgres .
+   ```
+
+2. **Run the PostgreSQL container**
+
+   You must provide all required PostgreSQL environment variables in the `docker run` command. These variables **must match** those defined in your `back/.env` file to ensure your backend can connect to the database.
+
+   Example:
+
+   ```bash
+   docker run -d \
+     --name slotfinder-db \
+     -e POSTGRES_USER=slotfinder \
+     -e POSTGRES_PASSWORD=slotfinder \
+     -e POSTGRES_DB=slotfinder \
+     -p 5432:5432 \
+     slotfinder-postgres
+   ```
+
+   Replace the values with those from your `back/.env` if they are different.
+
+
+3. **Stop and remove the container**
+
+   ```bash
+   docker stop slotfinder-db
+   docker rm slotfinder-db
+   ```
+


### PR DESCRIPTION
This pull request introduces a custom Docker setup for running PostgreSQL as part of the SlotFinder project. It adds a new `Dockerfile` for building a PostgreSQL image and provides clear instructions in the `README.md` on how to build, run, and manage the database container.

**Docker support for PostgreSQL:**

* Added a `Dockerfile` in the `db/` directory to build a custom PostgreSQL 17 Alpine-based image and expose port 5432.

**Documentation:**

* Added a `README.md` in the `db/` directory with step-by-step instructions for building, running, and stopping the PostgreSQL Docker container, including guidance on configuring environment variables to match the backend.