### PR TITLE
chore: disable updates for github.com/swaggo/files package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,12 @@
       "matchDatasources": ["npm"],
       "groupName": "react-query mono repo",
       "matchSourceUrls": ["https://github.com/TanStack/query"]
+    },
+    {
+      "matchPackageNames": [
+        "github.com/swaggo/files"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This pull request makes a configuration update to `.github/renovate.json` to disable Renovate updates for a specific package.

Renovate configuration changes:

* Disabled Renovate updates for the `github.com/swaggo/files` package by adding a new entry with `"enabled": false` in the configuration.