### PR TITLE
feat(i18n): implement internationalization support

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,9 +13,11 @@
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.90.1",
         "@tanstack/react-query-devtools": "^5.90.1",
+        "i18next": "^25.5.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.63.0",
+        "react-i18next": "^15.7.3",
         "react-router": "^7.9.1",
         "yup": "^1.7.1"
       },
@@ -37,6 +39,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "concurrently": "^9.2.1",
         "husky": "^9.1.7",
+        "i18next-resources-for-ts": "^1.7.4",
         "jsdom": "^27.0.0",
         "lint-staged": "^16.2.0",
         "monocart-coverage-reports": "^2.12.9",
@@ -358,7 +361,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7378,6 +7380,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -7433,6 +7444,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.5.2.tgz",
+      "integrity": "sha512-lW8Zeh37i/o0zVr+NoCHfNnfvVw+M6FQbRp36ZZ/NyHDJ3NJVpp2HhAUyU9WafL5AssymNoOjMRB48mmx2P6Hw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-resources-for-ts": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/i18next-resources-for-ts/-/i18next-resources-for-ts-1.7.4.tgz",
+      "integrity": "sha512-3NpN2zasOWYR5zWA4JIdFhxrHxRJV8HEsbR7/GHSnotfjArjZzKvOzQnLFZ911QFmmcwq80saw8rccpHH+MYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.0",
+        "yaml": "^2.7.1"
+      },
+      "bin": {
+        "i18next-resources-for-ts": "bin/i18next-resources-for-ts.js"
       }
     },
     "node_modules/iconv-lite": {
@@ -9969,6 +10025,32 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.3.tgz",
+      "integrity": "sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.4.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -11975,7 +12057,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12366,6 +12448,15 @@
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -22,15 +22,18 @@
     "lint:tsc": "tsc --noEmit",
     "package:check": "npm exec --yes package-lock-utd@1.1.3",
     "prepare": "cd .. && husky front/.husky",
-    "postinstall": "msw init"
+    "postinstall": "msw init",
+    "i18next-resources-for-ts": "i18next-resources-for-ts toc -i ./src/i18n/locales/en -o ./src/i18n/@types/resources.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.1",
     "@tanstack/react-query-devtools": "^5.90.1",
+    "i18next": "^25.5.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.63.0",
+    "react-i18next": "^15.7.3",
     "react-router": "^7.9.1",
     "yup": "^1.7.1"
   },
@@ -52,6 +55,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "concurrently": "^9.2.1",
     "husky": "^9.1.7",
+    "i18next-resources-for-ts": "^1.7.4",
     "jsdom": "^27.0.0",
     "lint-staged": "^16.2.0",
     "monocart-coverage-reports": "^2.12.9",

--- a/front/src/bootstrap.tsx
+++ b/front/src/bootstrap.tsx
@@ -1,3 +1,4 @@
+import '@Front/i18n';
 import { StrictMode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { App } from './components/App/App';

--- a/front/src/i18n/@types/i18next.d.ts
+++ b/front/src/i18n/@types/i18next.d.ts
@@ -1,0 +1,9 @@
+import { type defaultNS } from '../i18n/config';
+import type resources from './resources';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: typeof defaultNS;
+    resources: typeof resources;
+  }
+}

--- a/front/src/i18n/@types/resources.ts
+++ b/front/src/i18n/@types/resources.ts
@@ -1,0 +1,7 @@
+import home from '../locales/en/home.json';
+
+const resources = {
+  home
+} as const;
+
+export default resources;

--- a/front/src/i18n/README.md
+++ b/front/src/i18n/README.md
@@ -1,0 +1,67 @@
+# i18n Directory
+
+This directory contains all resources and configuration for internationalization (i18n) in the project.
+
+## Purpose
+
+- Centralize all translation files and i18n configuration in one place.
+- Enable type-safe and autocompleted translation keys in TypeScript.
+- Make it easy to add new namespaces (pages/features) or update translations.
+- Keep translation logic separated from business and UI code.
+
+## Structure
+
+```
+src/i18n/
+  index.ts                # i18n initialization and configuration
+  @types/
+    i18next.d.ts          # i18next type augmentation
+    resources.ts          # TypeScript types for translation keys (auto-generated)
+  locales/
+    en/
+      home.json           # English translations for Home page
+      ...                 # Add more namespaces as needed
+      index.ts            # (optional) re-exports for namespaces
+```
+
+## How it works
+
+- Translation files are written in JSON, organized by namespace (one file per page/feature).
+- The `i18next-resources-for-ts` script scans all translation files and generates TypeScript types in `@types/resources.ts`.
+- The i18n config (`index.ts`) loads all namespaces and provides them to i18next.
+- You get autocompletion and type safety for translation keys in your components.
+
+## Usage in the App
+
+- Import `src/i18n` in your app entry point (e.g., `main.ts` or `App.tsx`).
+- Use the `useTranslation` hook from `react-i18next` in your components.
+
+## Example
+
+```tsx
+import { useTranslation } from 'react-i18next';
+
+const { t } = useTranslation('home');
+
+t('welcome');
+```
+
+## Adding or Updating Translations
+
+1. Add or edit a JSON file in `locales/en/` (e.g., `profile.json`).
+2. Run the script to update types:
+
+   ```sh
+   npm run i18next-resources-for-ts
+   ```
+
+3. Use the new keys in your code with autocompletion and type safety.
+
+## Notes
+
+- The types in `@types/resources.ts` is auto-generated. Do not edit it manually.
+- You can add more languages by creating new folders in `locales/` and updating the i18n config.
+
+---
+
+For more details, see the [react-i18next documentation](https://react.i18next.com/) and [i18next-resources-for-ts](https://www.npmjs.com/package/i18next-resources-for-ts).

--- a/front/src/i18n/index.ts
+++ b/front/src/i18n/index.ts
@@ -1,0 +1,13 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import { en } from './locales/en';
+
+// oxlint-disable-next-line no-named-as-default-member
+i18n.use(initReactI18next).init({
+  resources: {
+    en,
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});

--- a/front/src/i18n/locales/en/home.json
+++ b/front/src/i18n/locales/en/home.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome to the Home page!"
+}

--- a/front/src/i18n/locales/en/index.ts
+++ b/front/src/i18n/locales/en/index.ts
@@ -1,0 +1,5 @@
+import enHome from './home.json';
+
+export const en = {
+  home: enHome,
+};

--- a/front/src/pages/Home/Home.tsx
+++ b/front/src/pages/Home/Home.tsx
@@ -1,5 +1,11 @@
-export const Home = () => (
-  <main>
-    <h1>Home</h1>
-  </main>
-);
+import { useTranslation } from 'react-i18next';
+
+export const Home = () => {
+  const { t } = useTranslation('home');
+
+  return (
+    <main>
+      <h1>{t('welcome')}</h1>
+    </main>
+  );
+};


### PR DESCRIPTION
**Title:** Add i18n support to front-end with react-i18next and type-safe resources

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
This change introduces internationalization (i18n) support to the front-end application, enabling type-safe translations and future multi-language capabilities. It centralizes translation resources and integrates `react-i18next` for seamless usage in React components.

**Proposed Changes:**
- Added `i18next`, `react-i18next`, and `i18next-resources-for-ts` dependencies.
- Created a new `src/i18n` directory with configuration, type augmentation, and auto-generated resource types.
- Added English translation namespace for the Home page.
- Updated the Home page to use the `useTranslation` hook and display a translated welcome message.
- Updated `bootstrap.tsx` to initialize i18n at app startup.
- Updated `package.json` scripts for i18n type generation.
- Added documentation for the i18n setup and usage.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None