### PR TITLE
feat(front): use i18n for Sign Up page instead of hard coded constants

### DIFF
--- a/front/src/i18n/@types/resources.ts
+++ b/front/src/i18n/@types/resources.ts
@@ -1,7 +1,9 @@
 import home from '../locales/en/home.json';
+import signUp from '../locales/en/signUp.json';
 
 const resources = {
-  home
+  home,
+  signUp
 } as const;
 
 export default resources;

--- a/front/src/i18n/locales/en/index.ts
+++ b/front/src/i18n/locales/en/index.ts
@@ -1,5 +1,7 @@
 import enHome from './home.json';
+import enSignUp from './signUp.json';
 
 export const en = {
   home: enHome,
+  signUp: enSignUp,
 };

--- a/front/src/i18n/locales/en/signUp.json
+++ b/front/src/i18n/locales/en/signUp.json
@@ -1,0 +1,14 @@
+{
+  "title": "Sign Up",
+  "username": "Username",
+  "requiredUsername": "Username is required",
+  "minLengthUsername": "Username must be at least {{min}} characters",
+  "email": "Email",
+  "requiredEmail": "Email is required",
+  "invalidEmail": "Invalid email address",
+  "password": "Password",
+  "requiredPassword": "Password is required",
+  "minLengthPassword": "Password must be at least {{min}} characters",
+  "passwordComplexity": "Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character",
+  "submit": "Create Account"
+}

--- a/front/src/pages/SignUp/SignUp.tsx
+++ b/front/src/pages/SignUp/SignUp.tsx
@@ -2,26 +2,14 @@ import { useSignUp } from '@Front/hooks/api/useSignUp';
 import type { SignUpFormType } from '@Front/types/Authentication/signUp.types';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
-import { object, string } from 'yup';
-import { PASSWORD_MIN_LENGTH, USERNAME_MIN_LENGTH } from './constants';
-
-const schema = object({
-  username: string()
-    .required('Username is required')
-    .min(USERNAME_MIN_LENGTH, `Username must be at least ${USERNAME_MIN_LENGTH} characters`),
-  email: string().email('Invalid email').required('Email is required'),
-  password: string()
-    .required('Password is required')
-    .min(PASSWORD_MIN_LENGTH, `Password must be at least ${PASSWORD_MIN_LENGTH} characters`)
-    .matches(/[A-Za-z]/, 'Password must contain letters')
-    .matches(/\d/, 'Password must contain numbers')
-    .matches(/[^A-Za-z0-9]/, 'Password must contain symbols'),
-});
+import { useTranslation } from 'react-i18next';
+import { getSchema } from './validation';
 
 export const SignUp = () => {
   const { signUp, isLoading, error } = useSignUp();
+  const { t } = useTranslation('signUp');
   const methods = useForm<SignUpFormType>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(getSchema(t)),
   });
 
   return (
@@ -33,11 +21,11 @@ export const SignUp = () => {
       >
         <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
           <legend id="signup-legend" style={{ fontWeight: 'bold', marginBottom: '1rem' }}>
-            Sign Up
+            {t('title')}
           </legend>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-            <label htmlFor="username">Username</label>
+            <label htmlFor="username">{t('username')}</label>
             <input
               id="username"
               type="text"
@@ -53,10 +41,10 @@ export const SignUp = () => {
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-            <label htmlFor="email">Email</label>
+            <label htmlFor="email">{t('email')}</label>
             <input
               id="email"
-              type="email"
+              type="text"
               autoComplete="email"
               aria-describedby={methods.formState.errors.email ? 'email-error' : undefined}
               {...methods.register('email')}
@@ -69,7 +57,7 @@ export const SignUp = () => {
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-            <label htmlFor="password">Password</label>
+            <label htmlFor="password">{t('password')}</label>
             <input
               id="password"
               type="password"
@@ -90,7 +78,7 @@ export const SignUp = () => {
           </span>
         )}
         <button type="submit" style={{ marginTop: '1rem' }} disabled={isLoading}>
-          Sign Up
+          {t('submit')}
         </button>
       </form>
     </FormProvider>

--- a/front/src/pages/SignUp/__tests__/SignUp.test.tsx
+++ b/front/src/pages/SignUp/__tests__/SignUp.test.tsx
@@ -15,50 +15,56 @@ afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
 describe('SignUp', () => {
+  vi.mock('react-i18next', () => ({
+    useTranslation: vi.fn().mockReturnValue({
+      t: (messageId: string, args: Record<string, unknown>) => messageId + (args ? `::${JSON.stringify(args)}` : ''),
+    }),
+  }));
+
   it('renders all form fields and submit button', () => {
     renderWithProvider(<SignUp />);
-    expect(screen.getByLabelText('Username')).toBeInTheDocument();
-    expect(screen.getByLabelText('Email')).toBeInTheDocument();
-    expect(screen.getByLabelText('Password')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /sign up/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('username')).toBeInTheDocument();
+    expect(screen.getByLabelText('email')).toBeInTheDocument();
+    expect(screen.getByLabelText('password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'submit' })).toBeInTheDocument();
   });
 
   it('shows validation errors for empty fields', async () => {
     renderWithProvider(<SignUp />);
-    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
 
-    expect(await screen.findByText('Username is required')).toBeInTheDocument();
-    expect(screen.getByText('Email is required')).toBeInTheDocument();
-    expect(screen.getByText('Password is required')).toBeInTheDocument();
+    expect(await screen.findByText('requiredUsername')).toBeInTheDocument();
+    expect(screen.getByText('requiredEmail')).toBeInTheDocument();
+    expect(screen.getByText('requiredPassword')).toBeInTheDocument();
   });
 
   it.each([
     {
       password: '1234567',
-      expectedError: 'Password must be at least 8 characters',
+      expectedError: 'minLengthPassword::{"min":8}',
       description: 'minimum length error',
     },
     {
       password: '12345678!',
-      expectedError: 'Password must contain letters',
+      expectedError: 'passwordComplexity',
       description: 'must contain letters error',
     },
     {
       password: 'Password!',
-      expectedError: 'Password must contain numbers',
+      expectedError: 'passwordComplexity',
       description: 'must contain numbers error',
     },
     {
       password: 'Password1',
-      expectedError: 'Password must contain symbols',
+      expectedError: 'passwordComplexity',
       description: 'must contain symbols error',
     },
   ])('shows password $description', async ({ password, expectedError }) => {
     renderWithProvider(<SignUp />);
-    await userEvent.type(screen.getByLabelText('Username'), 'testuser');
-    await userEvent.type(screen.getByLabelText('Email'), 'test@example.com');
-    await userEvent.type(screen.getByLabelText('Password'), password);
-    await userEvent.click(screen.getByRole('button', { name: 'Sign Up' }));
+    await userEvent.type(screen.getByLabelText('username'), 'testuser');
+    await userEvent.type(screen.getByLabelText('email'), 'test@example.com');
+    await userEvent.type(screen.getByLabelText('password'), password);
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
 
     expect(await screen.findByText(expectedError)).toBeInTheDocument();
   });
@@ -71,10 +77,10 @@ describe('SignUp', () => {
     });
 
     renderWithProvider(<SignUp />);
-    await userEvent.type(screen.getByLabelText('Username'), 'failuser');
-    await userEvent.type(screen.getByLabelText('Email'), 'fail@example.com');
-    await userEvent.type(screen.getByLabelText('Password'), 'Password1!');
-    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+    await userEvent.type(screen.getByLabelText('username'), 'failuser');
+    await userEvent.type(screen.getByLabelText('email'), 'fail@example.com');
+    await userEvent.type(screen.getByLabelText('password'), 'Password1!');
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
 
     expect(await screen.findByText('Username already exists')).toBeInTheDocument();
   });

--- a/front/src/pages/SignUp/constants.ts
+++ b/front/src/pages/SignUp/constants.ts
@@ -1,2 +1,4 @@
 export const USERNAME_MIN_LENGTH = 2;
+export const EMAIL_REGEX = /^[\w.-]+@[\w.-]+\.[a-zA-Z]{2,}$/;
 export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;

--- a/front/src/pages/SignUp/validation.ts
+++ b/front/src/pages/SignUp/validation.ts
@@ -1,0 +1,15 @@
+import type { TFunction } from 'i18next';
+import { object, string } from 'yup';
+import { EMAIL_REGEX, PASSWORD_MIN_LENGTH, PASSWORD_REGEX, USERNAME_MIN_LENGTH } from './constants';
+
+export const getSchema = (translate: TFunction) =>
+  object({
+    username: string()
+      .required(translate('requiredUsername'))
+      .min(USERNAME_MIN_LENGTH, translate('minLengthUsername', { min: USERNAME_MIN_LENGTH })),
+    email: string().required(translate('requiredEmail')).matches(EMAIL_REGEX, translate('invalidEmail')),
+    password: string()
+      .required(translate('requiredPassword'))
+      .min(PASSWORD_MIN_LENGTH, translate('minLengthPassword', { min: PASSWORD_MIN_LENGTH }))
+      .matches(PASSWORD_REGEX, translate('passwordComplexity')),
+  });


### PR DESCRIPTION
**Title:** Use i18n for Sign Up page instead of hard coded constants

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
The Sign Up page previously used hard coded constants for labels and validation messages. This change aims to improve maintainability and enable localization by leveraging the i18n system for all user-facing text on the Sign Up page.

**Proposed Changes:**
- Added new i18n resource files for the Sign Up page (`signUp.json`).
- Updated i18n resource type definitions and English locale index to include Sign Up translations.
- Refactored the Sign Up page to use i18n keys for all labels, placeholders, and validation messages instead of hard coded constants.

**Checklist:**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [ ] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None