### PR TITLE
chore(front): remove unused browserslist configuration

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -78,18 +78,6 @@
     "node": "22.20.0",
     "npm": "11.6.0"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "msw": {
     "workerDirectory": [
       "./public"


### PR DESCRIPTION
**Title:** Remove unused "browserslist" property from front/package.json

**Type of Pull Request:**

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (specify): Configuration cleanup

**Associated Issue:**
N/A

**Context:**
The "browserslist" property in `front/package.json` was previously used for Playwright, but Playwright is not utilized in this project. Keeping unused configuration can cause confusion and maintenance overhead.

**Proposed Changes:**
- Remove the "browserslist" property from `front/package.json`.
- Clean up configuration to reflect actual project dependencies and usage.

**Checklist:**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None