### PR TITLE
feat(front): add oauth callback

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,7 +18,7 @@
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.63.0",
         "react-i18next": "^16.0.0",
-        "react-router": "^7.9.2",
+        "react-router-dom": "^7.9.3",
         "yup": "^1.7.1"
       },
       "devDependencies": {
@@ -10320,6 +10320,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-router/node_modules/cookie": {

--- a/front/package.json
+++ b/front/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.63.0",
     "react-i18next": "^16.0.0",
-    "react-router": "^7.9.2",
+    "react-router-dom": "^7.9.3",
     "yup": "^1.7.1"
   },
   "devDependencies": {

--- a/front/src/components/App/App.tsx
+++ b/front/src/components/App/App.tsx
@@ -1,7 +1,7 @@
 import { queryClient } from '@Front/config';
 import { withProvider } from '@Front/providers';
 import { createRouter } from '@Front/routing/routerFactory';
-import { RouterProvider } from 'react-router';
+import { RouterProvider } from 'react-router-dom';
 
 import '@Front/assets/css';
 

--- a/front/src/components/Layout/index.tsx
+++ b/front/src/components/Layout/index.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router';
+import { Outlet } from 'react-router-dom';
 import { DebugGrid } from '../DebugGrid/DebugGrid';
 
 export const Layout = () => (

--- a/front/src/i18n/@types/resources.ts
+++ b/front/src/i18n/@types/resources.ts
@@ -1,9 +1,11 @@
 import authentication from '../locales/en/authentication.json';
+import error from '../locales/en/error.json';
 import home from '../locales/en/home.json';
 import signUp from '../locales/en/signUp.json';
 
 const resources = {
   authentication,
+  error,
   home,
   signUp
 } as const;

--- a/front/src/i18n/locales/en/error.json
+++ b/front/src/i18n/locales/en/error.json
@@ -1,0 +1,4 @@
+{
+  "title": "Error",
+  "unexpected": "An unexpected error occurred."
+}

--- a/front/src/i18n/locales/en/index.ts
+++ b/front/src/i18n/locales/en/index.ts
@@ -1,4 +1,5 @@
 import enAuthentication from './authentication.json';
+import enError from './error.json';
 import enHome from './home.json';
 import enSignUp from './signUp.json';
 
@@ -6,4 +7,5 @@ export const en = {
   home: enHome,
   signUp: enSignUp,
   authentication: enAuthentication,
+  error: enError,
 };

--- a/front/src/pages/Authentication/Authentication.tsx
+++ b/front/src/pages/Authentication/Authentication.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router';
+import { Outlet } from 'react-router-dom';
 import { OAuth } from './OAuth';
 
 export const Authentication = () => (

--- a/front/src/pages/Authentication/SignUp/routes.tsx
+++ b/front/src/pages/Authentication/SignUp/routes.tsx
@@ -1,4 +1,4 @@
-import type { RouteObject } from 'react-router';
+import type { RouteObject } from 'react-router-dom';
 import { SignUp } from './SignUp';
 
 export const signUpRoutes: RouteObject = {

--- a/front/src/pages/Authentication/routes.tsx
+++ b/front/src/pages/Authentication/routes.tsx
@@ -1,4 +1,4 @@
-import type { RouteObject } from 'react-router';
+import type { RouteObject } from 'react-router-dom';
 import { Authentication } from './Authentication';
 import { signUpRoutes } from './SignUp';
 

--- a/front/src/pages/Error/Error.tsx
+++ b/front/src/pages/Error/Error.tsx
@@ -1,0 +1,14 @@
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+
+export const ErrorPage = () => {
+  const { t } = useTranslation('error');
+  const location = useLocation();
+
+  return (
+    <main>
+      <h1>{t('title')}</h1>
+      <p role="alert">{location.state?.message || t('unexpected')}</p>
+    </main>
+  );
+};

--- a/front/src/pages/Error/__tests__/Error.test.tsx
+++ b/front/src/pages/Error/__tests__/Error.test.tsx
@@ -1,0 +1,33 @@
+import { errorRoutes } from '@Front/pages/Error';
+import { appRoutes } from '@Front/routing/appRoutes';
+import { renderRoute } from '@Front/utils/testsUtils/renderRoute';
+import { screen } from '@testing-library/react';
+import type { InitialEntry } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+const renderErrorPage = (message?: string) => {
+  const initialEntries: InitialEntry[] = [];
+
+  if (message) {
+    initialEntries.push({ pathname: appRoutes.error(), state: { message } });
+  } else {
+    initialEntries.push(appRoutes.error());
+  }
+
+  return renderRoute({
+    routes: [errorRoutes],
+    routesOptions: { initialEntries },
+  });
+};
+
+describe('ErrorPage', () => {
+  it('should display the error message when provided in state', async () => {
+    renderErrorPage('TestError');
+    expect(await screen.findByRole('alert')).toHaveTextContent('TestError');
+  });
+
+  it('should display the default unexpected message when no message is provided', async () => {
+    renderErrorPage();
+    expect(await screen.findByRole('alert')).toHaveTextContent('unexpected');
+  });
+});

--- a/front/src/pages/Error/index.ts
+++ b/front/src/pages/Error/index.ts
@@ -1,0 +1,1 @@
+export { errorRoutes } from './routes';

--- a/front/src/pages/Error/routes.tsx
+++ b/front/src/pages/Error/routes.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { ErrorPage } from './Error';
+
+export const errorRoutes: RouteObject = {
+  path: 'error',
+  element: <ErrorPage />,
+};

--- a/front/src/pages/Home/Home.tsx
+++ b/front/src/pages/Home/Home.tsx
@@ -1,6 +1,6 @@
 import { appRoutes } from '@Front/routing/appRoutes';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router';
+import { NavLink } from 'react-router-dom';
 
 export const Home = () => {
   const { t } = useTranslation('home');

--- a/front/src/pages/Home/routes.tsx
+++ b/front/src/pages/Home/routes.tsx
@@ -1,4 +1,4 @@
-import type { RouteObject } from 'react-router';
+import type { RouteObject } from 'react-router-dom';
 import { Home } from './Home';
 
 export const homeRoutes: RouteObject = {

--- a/front/src/pages/OAuthCallback/OAuthCallback.tsx
+++ b/front/src/pages/OAuthCallback/OAuthCallback.tsx
@@ -1,0 +1,12 @@
+import { Navigate, useSearchParams } from 'react-router-dom';
+
+export const OAuthCallback = () => {
+  const [searchParams] = useSearchParams();
+  const message = searchParams.get('message');
+
+  if (message) {
+    return <Navigate to="/error" state={{ message }} replace />;
+  }
+
+  return <Navigate to="/" replace />;
+};

--- a/front/src/pages/OAuthCallback/__tests__/OAuthCallback.test.tsx
+++ b/front/src/pages/OAuthCallback/__tests__/OAuthCallback.test.tsx
@@ -1,0 +1,25 @@
+import { errorRoutes } from '@Front/pages/Error';
+import { homeRoutes } from '@Front/pages/Home';
+import { appRoutes } from '@Front/routing/appRoutes';
+import { renderRoute } from '@Front/utils/testsUtils/renderRoute';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { oauthCallbackRoutes } from '../routes';
+
+const renderOAuthCallback = (message?: string) =>
+  renderRoute({
+    routes: [oauthCallbackRoutes, homeRoutes, errorRoutes],
+    routesOptions: { initialEntries: [appRoutes.oAuthCallback(message)] },
+  });
+
+describe('OAuthCallback', () => {
+  it('should redirect to /error with state when message param is present', async () => {
+    renderOAuthCallback('TestError');
+    expect(await screen.findByText('TestError')).toBeInTheDocument();
+  });
+
+  it('should redirect to / when no message param is present', async () => {
+    renderOAuthCallback();
+    expect(await screen.findByText('welcome')).toBeInTheDocument();
+  });
+});

--- a/front/src/pages/OAuthCallback/index.ts
+++ b/front/src/pages/OAuthCallback/index.ts
@@ -1,0 +1,1 @@
+export { oauthCallbackRoutes } from './routes';

--- a/front/src/pages/OAuthCallback/routes.tsx
+++ b/front/src/pages/OAuthCallback/routes.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { OAuthCallback } from './OAuthCallback';
+
+export const oauthCallbackRoutes: RouteObject = {
+  path: 'oauth/callback',
+  element: <OAuthCallback />,
+};

--- a/front/src/pages/README.md
+++ b/front/src/pages/README.md
@@ -49,7 +49,7 @@ Suppose we have a "UserProfile" page with a complex structure:
 export { userProfileRoutes } from './routes';
 
 // routes.tsx (react-router v7)
-import { RouteObject } from 'react-router';
+import { RouteObject } from 'react-router-dom';
 import { UserProfile } from './UserProfile';
 
 export const userProfileRoutes: RouteObject = {

--- a/front/src/routing/appRoutes.ts
+++ b/front/src/routing/appRoutes.ts
@@ -1,6 +1,23 @@
 import { signUpRoutes } from '@Front/pages/Authentication/SignUp';
+import { errorRoutes } from '@Front/pages/Error';
+import { oauthCallbackRoutes } from '@Front/pages/OAuthCallback';
 
-export const appRoutes: Record<string, () => string> = {
+type AppRoute = {
+  home: () => string;
+  signUp: () => string;
+  oAuthCallback: (message?: string) => string;
+  error: () => string;
+};
+
+export const appRoutes: AppRoute = {
   home: () => '/',
   signUp: () => `/${signUpRoutes.path}`,
+  oAuthCallback: message => {
+    let route = `/${oauthCallbackRoutes.path}`;
+    if (message) {
+      route += `?message=${encodeURIComponent(message)}`;
+    }
+    return route;
+  },
+  error: () => `/${errorRoutes.path}`,
 };

--- a/front/src/routing/routerFactory.ts
+++ b/front/src/routing/routerFactory.ts
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router';
+import { createBrowserRouter } from 'react-router-dom';
 import { routeObject } from './routes';
 
 interface CreateRouterProps {

--- a/front/src/routing/routes.tsx
+++ b/front/src/routing/routes.tsx
@@ -1,12 +1,14 @@
 import { Layout } from '@Front/components/Layout';
 import { authenticationRoutes } from '@Front/pages/Authentication';
+import { errorRoutes } from '@Front/pages/Error';
 import { homeRoutes } from '@Front/pages/Home';
-import type { RouteObject } from 'react-router';
+import { oauthCallbackRoutes } from '@Front/pages/OAuthCallback';
+import type { RouteObject } from 'react-router-dom';
 
 export const routeObject: RouteObject[] = [
   {
     path: '/',
     element: <Layout />,
-    children: [homeRoutes, authenticationRoutes],
+    children: [homeRoutes, authenticationRoutes, oauthCallbackRoutes, errorRoutes],
   },
 ];

--- a/front/src/utils/testsUtils/renderRoute/index.tsx
+++ b/front/src/utils/testsUtils/renderRoute/index.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, type RenderOptions } from '@testing-library/react';
 import type { ComponentProps } from 'react';
-import { createMemoryRouter, RouterProvider, type MemoryRouterOpts, type RouteObject } from 'react-router';
+import { createMemoryRouter, RouterProvider, type MemoryRouterOpts, type RouteObject } from 'react-router-dom';
 
 export type RenderRouteOptions = {
   routes: RouteObject[];


### PR DESCRIPTION
**Title:** Implement OAuth callback handling and error page integration

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
This change introduces OAuth callback handling in the frontend and adds a dedicated error page to improve user experience during authentication flows. It also updates routing and i18n resources to support these new features.

**Proposed Changes:**
- Added `OAuthCallback` page to handle OAuth redirect and error messaging.
- Created `ErrorPage` for displaying error messages, with i18n support.
- Updated routing to include new OAuth callback and error routes.
- Refactored all usages of `react-router` to `react-router-dom` for compatibility.
- Added English error translations and integrated them into i18n resources.
- Provided unit tests for both OAuth callback and error page behaviors.
- Updated navigation and route definitions to support new pages.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None