### PR TITLE
feat(back): manage oauth redirection

### DIFF
--- a/back/config/config.go
+++ b/back/config/config.go
@@ -47,5 +47,9 @@ func GetOrigin() (origins []string) {
 		origins[i] = strings.TrimSpace(origin)
 	}
 
+	if len(origins) == 0 {
+		panic("ORIGINS environment variable is not set")
+	}
+
 	return origins
 }

--- a/back/docs/docs.go
+++ b/back/docs/docs.go
@@ -131,40 +131,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/v1/auth/providers/url": {
-            "get": {
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "Get all redirect URLs for each OAuth provider",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "URL to redirect after OAuth authentication",
-                        "name": "redirectUrl",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OAuth URL",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ApiError"
-                        }
-                    }
-                }
-            }
-        },
         "/v1/auth/signin": {
             "post": {
                 "description": "Sign in with email and password",

--- a/back/docs/swagger.json
+++ b/back/docs/swagger.json
@@ -123,40 +123,6 @@
                 }
             }
         },
-        "/v1/auth/providers/url": {
-            "get": {
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "Get all redirect URLs for each OAuth provider",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "URL to redirect after OAuth authentication",
-                        "name": "redirectUrl",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OAuth URL",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/helpers.ApiError"
-                        }
-                    }
-                }
-            }
-        },
         "/v1/auth/signin": {
             "post": {
                 "description": "Sign in with email and password",

--- a/back/docs/swagger.yaml
+++ b/back/docs/swagger.yaml
@@ -232,28 +232,6 @@ paths:
       summary: Get redirect URL for OAuth provider
       tags:
       - Authentication
-  /v1/auth/providers/url:
-    get:
-      parameters:
-      - description: URL to redirect after OAuth authentication
-        in: query
-        name: redirectUrl
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OAuth URL
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/helpers.ApiError'
-      summary: Get all redirect URLs for each OAuth provider
-      tags:
-      - Authentication
   /v1/auth/signin:
     post:
       consumes:

--- a/back/pkg/provider/provider.service.go
+++ b/back/pkg/provider/provider.service.go
@@ -56,22 +56,7 @@ func (*ProviderService) parseProvider(provider string) (constants.Provider, erro
 	}
 }
 
-func (s *ProviderService) GetProviderUrls(redirectUrl string, user *guard.Claims) (providerUrls map[string]string, err error) {
-	providerUrls = make(map[string]string)
-
-	for _, provider := range constants.PROVIDERS {
-		url, err := s.GetProviderUrl(string(provider), redirectUrl, user)
-		if err != nil {
-			return providerUrls, err
-		}
-
-		providerUrls[string(provider)] = url
-	}
-
-	return providerUrls, nil
-}
-
-func (s *ProviderService) GetProviderUrl(providerEntry string, redirectUrl string, user *guard.Claims) (string, error) {
+func (s *ProviderService) GetProviderUrl(providerEntry string, user *guard.Claims) (string, error) {
 	provider, err := s.parseProvider(providerEntry)
 	if err != nil {
 		return "", err
@@ -82,8 +67,7 @@ func (s *ProviderService) GetProviderUrl(providerEntry string, redirectUrl strin
 		userId = user.Id.String()
 	}
 	jsonState, _ := json.Marshal(map[string]string{
-		"redirectUrl": redirectUrl,
-		"userId":      userId,
+		"userId": userId,
 	})
 	jsonStateEncrypted, err := encryption.Encrypt(string(jsonState))
 	if err != nil {

--- a/back/server/router.go
+++ b/back/server/router.go
@@ -48,7 +48,6 @@ func NewRouter() *gin.Engine {
 
 			authGroup.POST("signin", signinRouter.Signin)
 
-			authGroup.Use(guard.AuthCheck(false)).GET("/providers/url", providerRouter.ProvidersUrl)
 			authGroup.Use(guard.AuthCheck(false)).GET("/:provider/url", providerRouter.ProviderUrl)
 			authGroup.GET("/:provider/callback", providerRouter.ProviderCallback)
 


### PR DESCRIPTION
https://github.com/ZideStudio/SlotFinder/issues/84

This pull request refactors the OAuth provider URL flow by removing support for requesting all provider redirect URLs at once and simplifying the logic for generating provider URLs. It also enforces that the `ORIGINS` environment variable must be set, improving configuration reliability. The most significant changes are grouped below.

### API and Documentation Changes

* Removed the `/v1/auth/providers/url` endpoint and its associated documentation from `back/docs/docs.go`, `back/docs/swagger.json`, and `back/docs/swagger.yaml`. This endpoint previously allowed clients to request all OAuth provider redirect URLs at once. [[1]](diffhunk://#diff-d8d34fa914962b14ab111ab6ecb00e9ffa3def975d49780d08cd74ebdd8825b8L134-L167) [[2]](diffhunk://#diff-0ac683f0d3505c4b14d2ddc66de2671d83458d45b1cb9e93dd4c2a84157402c6L126-L159) [[3]](diffhunk://#diff-15ce78c87edf60b98a9b360adeaab97b50e6ad0b23aaa271eb950efdf14e3526L235-L256)
* Removed the corresponding route from `back/server/router.go`, so the endpoint is no longer accessible.

### Provider Controller and Service Refactor

* Simplified the provider URL logic in `provider.controller.go` and `provider.service.go` by removing the ability to specify a custom `redirectUrl` and the function to validate its origin. Now, the redirect URL is fixed to the first configured origin with `/oauth/callback` appended. [[1]](diffhunk://#diff-89589826f438d1de844dbe52464147fd539930d0338a9808b37f36eb2b7c0df2L12) [[2]](diffhunk://#diff-89589826f438d1de844dbe52464147fd539930d0338a9808b37f36eb2b7c0df2L31-L44) [[3]](diffhunk://#diff-89589826f438d1de844dbe52464147fd539930d0338a9808b37f36eb2b7c0df2L55-R52) [[4]](diffhunk://#diff-89589826f438d1de844dbe52464147fd539930d0338a9808b37f36eb2b7c0df2L132-R81) [[5]](diffhunk://#diff-bd4b152f5c70b895311db3c84ee039b36e9844c6d492b7ec5f1da2890806922fL59-R59) [[6]](diffhunk://#diff-bd4b152f5c70b895311db3c84ee039b36e9844c6d492b7ec5f1da2890806922fL85)

### Configuration Enforcement

* Added a panic in `config.go` to enforce that the `ORIGINS` environment variable must be set, preventing misconfiguration at startup.