### PR TITLE
chore(env): set default value to DOMAIN

### DIFF
--- a/back/.env.model
+++ b/back/.env.model
@@ -1,7 +1,7 @@
 GIN_MODE=release
 ENV=dev
 
-DOMAIN=
+DOMAIN=localhost
 ORIGINS=http://localhost:3000
 
 APP_HOST=localhost


### PR DESCRIPTION
This pull request updates the environment configuration for local development by setting the `DOMAIN` variable to `localhost` in the `back/.env.model` file.

Environment configuration update:

* Set the `DOMAIN` variable to `localhost` to ensure proper local development and routing.