### PR TITLE
feat(front): create authentication protection on routes

### DIFF
--- a/front/mocks/fixtures/authStatusFixtures.ts
+++ b/front/mocks/fixtures/authStatusFixtures.ts
@@ -1,5 +1,8 @@
-import type { ErrorResponseType } from "@Front/types/api.types";
-import type { AuthStatusErrorCodeType, AuthStatusResponseType } from "@Front/types/Authentication/authStatus/authStatus.types";
+import type { ErrorResponseType } from '@Front/types/api.types';
+import type {
+  AuthStatusErrorCodeType,
+  AuthStatusResponseType,
+} from '@Front/types/Authentication/authStatus/authStatus.types';
 
 export const authStatusFixture: AuthStatusResponseType = null;
 

--- a/front/mocks/fixtures/authStatusFixtures.ts
+++ b/front/mocks/fixtures/authStatusFixtures.ts
@@ -1,0 +1,8 @@
+import type { ErrorResponseType } from "@Front/types/api.types";
+import type { AuthStatusErrorCodeType, AuthStatusResponseType } from "@Front/types/Authentication/authStatus/authStatus.types";
+
+export const authStatusFixture: AuthStatusResponseType = null;
+
+export const authStatusErrorFixture: ErrorResponseType<AuthStatusErrorCodeType> = {
+  code: 'NOT_AUTHENTICATED',
+};

--- a/front/mocks/handlers/authStatusHandlers.ts
+++ b/front/mocks/handlers/authStatusHandlers.ts
@@ -1,0 +1,14 @@
+import { authStatusErrorFixture, authStatusFixture } from "@Mocks/fixtures/authStatusFixtures";
+import { delay, http, HttpResponse } from "msw";
+
+export const getAuthStatus200 = http.get(`${import.meta.env.FRONT_BACKEND_URL}/v1/auth/status`, async () => {
+  await delay();
+
+  return HttpResponse.json(authStatusFixture, { status: 200 });
+});
+
+export const getAuthStatus400 = http.get(`${import.meta.env.FRONT_BACKEND_URL}/v1/auth/status`, async () => {
+  await delay();
+
+  return HttpResponse.json(authStatusErrorFixture, { status: 400 });
+});

--- a/front/mocks/handlers/authStatusHandlers.ts
+++ b/front/mocks/handlers/authStatusHandlers.ts
@@ -1,5 +1,5 @@
-import { authStatusErrorFixture, authStatusFixture } from "@Mocks/fixtures/authStatusFixtures";
-import { delay, http, HttpResponse } from "msw";
+import { authStatusErrorFixture, authStatusFixture } from '@Mocks/fixtures/authStatusFixtures';
+import { delay, http, HttpResponse } from 'msw';
 
 export const getAuthStatus200 = http.get(`${import.meta.env.FRONT_BACKEND_URL}/v1/auth/status`, async () => {
   await delay();

--- a/front/mocks/server.ts
+++ b/front/mocks/server.ts
@@ -1,3 +1,5 @@
 import { setupServer } from 'msw/node';
+import { getAuthStatus200 } from './handlers/authStatusHandlers';
+import { getOAuthProviders200 } from './handlers/oAuthProvidersHandlers';
 
-export const server = setupServer();
+export const server = setupServer(getAuthStatus200, getOAuthProviders200);

--- a/front/src/api/authentication/authStatusApi.ts
+++ b/front/src/api/authentication/authStatusApi.ts
@@ -1,7 +1,10 @@
-import type { AuthStatusErrorCodeType, AuthStatusResponseType } from "@Front/types/Authentication/authStatus/authStatus.types";
-import { AuthStatusErrorResponse } from "@Front/types/Authentication/authStatus/AuthStatusErrorResponse";
-import { METHODS } from "../constant";
-import { fetchApi } from "../fetchApi";
+import type {
+  AuthStatusErrorCodeType,
+  AuthStatusResponseType,
+} from '@Front/types/Authentication/authStatus/authStatus.types';
+import { AuthStatusErrorResponse } from '@Front/types/Authentication/authStatus/AuthStatusErrorResponse';
+import { METHODS } from '../constant';
+import { fetchApi } from '../fetchApi';
 
 export const authStatusApi = () =>
   fetchApi<AuthStatusResponseType, AuthStatusErrorCodeType>({

--- a/front/src/api/authentication/authStatusApi.ts
+++ b/front/src/api/authentication/authStatusApi.ts
@@ -1,0 +1,12 @@
+import type { AuthStatusErrorCodeType, AuthStatusResponseType } from "@Front/types/Authentication/authStatus/authStatus.types";
+import { AuthStatusErrorResponse } from "@Front/types/Authentication/authStatus/AuthStatusErrorResponse";
+import { METHODS } from "../constant";
+import { fetchApi } from "../fetchApi";
+
+export const authStatusApi = () =>
+  fetchApi<AuthStatusResponseType, AuthStatusErrorCodeType>({
+    path: `${import.meta.env.FRONT_BACKEND_URL}/v1/auth/status`,
+    method: METHODS.get,
+    sendCredentials: true,
+    CustomErrorResponse: AuthStatusErrorResponse,
+  });

--- a/front/src/api/fetchApi.ts
+++ b/front/src/api/fetchApi.ts
@@ -14,14 +14,19 @@ type FetchApiProps<CustomErrorResponseCodeType extends string> = {
   method?: METHODS;
   data?: Json;
   headers?: HeadersInit;
+  sendCredentials?: boolean;
   CustomErrorResponse?: ErrorResponseClass<CustomErrorResponseCodeType>;
 };
 
-export const fetchApi = async <Response extends Json | string, CustomErrorResponseCodeType extends string = never>({
+export const fetchApi = async <
+  Response extends Json | string | null,
+  CustomErrorResponseCodeType extends string = never,
+>({
   path,
   method = METHODS.get,
   data,
   headers = [],
+  sendCredentials,
   CustomErrorResponse = ErrorResponse,
 }: FetchApiProps<CustomErrorResponseCodeType>): Promise<Response> => {
   const mergeHeaders = new Headers(headers);
@@ -33,6 +38,7 @@ export const fetchApi = async <Response extends Json | string, CustomErrorRespon
   const response = await fetch(path, {
     method,
     ...(data && { body: JSON.stringify(data) }),
+    credentials: sendCredentials ? 'include' : undefined,
     headers: mergeHeaders,
   });
 

--- a/front/src/components/AuthenticationProtection/__tests__/AuthenticationProtection.test.tsx
+++ b/front/src/components/AuthenticationProtection/__tests__/AuthenticationProtection.test.tsx
@@ -1,0 +1,63 @@
+import { appRoutes } from '@Front/routing/appRoutes';
+import { routeObject } from '@Front/routing/routes';
+import { renderRoute, type RenderRouteOptions } from '@Front/utils/testsUtils/customRender';
+import { getAuthStatus200, getAuthStatus400 } from '@Mocks/handlers/authStatusHandlers';
+import { server } from '@Mocks/server';
+import { screen } from '@testing-library/react';
+
+const getRenderRouteOptions = (initialEntry: string): RenderRouteOptions => ({
+  routes: routeObject,
+  routesOptions: { initialEntries: [initialEntry] },
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+describe('AuthenticationProtection with valid credentials', () => {
+  beforeEach(() => {
+    server.use(getAuthStatus200);
+  });
+
+  it('should render children when route does not require authentication and the user is authenticated', async () => {
+    renderRoute(getRenderRouteOptions(appRoutes.home()));
+
+    expect(await screen.findByText('home.welcome')).toBeInTheDocument();
+  });
+
+  it('should render children when route requires authentication and the user is authenticated', async () => {
+    renderRoute(getRenderRouteOptions(appRoutes.dashboard()));
+
+    expect(await screen.findByText('dashboard.title')).toBeInTheDocument();
+  });
+
+  it('should redirect to dashboard when route requires no authentication and the user is authenticated', async () => {
+    renderRoute(getRenderRouteOptions(appRoutes.signUp()));
+
+    expect(await screen.findByText('dashboard.title')).toBeInTheDocument();
+  });
+});
+
+describe('AuthenticationProtection with invalid credentials', () => {
+  beforeEach(() => {
+    server.use(getAuthStatus400);
+  });
+
+  it('should render children when route does not require authentication and the user is not authenticated', async () => {
+    renderRoute(getRenderRouteOptions(appRoutes.home()));
+
+    expect(await screen.findByText('home.welcome')).toBeInTheDocument();
+  });
+
+  it('should redirect to signUp when route requires authentication and the user is not authenticated', async () => {
+    renderRoute(getRenderRouteOptions(appRoutes.dashboard()));
+
+    expect(await screen.findByText('signUp.title')).toBeInTheDocument();
+  });
+
+  it('should render children when route requires no authentication and the user is not authenticated', async () => {
+    renderRoute(getRenderRouteOptions(appRoutes.signUp()));
+
+    expect(await screen.findByText('signUp.title')).toBeInTheDocument();
+  });
+});

--- a/front/src/components/AuthenticationProtection/index.tsx
+++ b/front/src/components/AuthenticationProtection/index.tsx
@@ -1,0 +1,33 @@
+import { useAuthenticationContext } from '@Front/hooks/useAuthenticationContext';
+import { appRoutes } from '@Front/routing/appRoutes';
+import { useMemo, type ReactNode } from 'react';
+import { Navigate, useLocation, useMatches, type UIMatch } from 'react-router-dom';
+
+type AuthenticationProtectionProps = {
+  children: ReactNode;
+};
+
+export const AuthenticationProtection = ({ children }: AuthenticationProtectionProps) => {
+  const { isAuthenticated } = useAuthenticationContext();
+  const { pathname } = useLocation();
+  const matches = useMatches() as UIMatch<unknown, { mustBeAuthenticate?: boolean }>[];
+
+  const mustBeAuthenticate = useMemo(() => {
+    const currentMatch = matches.find(match => match.pathname === pathname);
+    return currentMatch?.handle?.mustBeAuthenticate;
+  }, [matches, pathname]);
+
+  if (isAuthenticated === undefined) {
+    return null;
+  }
+
+  if (mustBeAuthenticate && !isAuthenticated) {
+    return <Navigate to={appRoutes.signUp()} replace />;
+  }
+
+  if (mustBeAuthenticate === false && isAuthenticated) {
+    return <Navigate to={appRoutes.dashboard()} replace />;
+  }
+
+  return children;
+};

--- a/front/src/contexts/AuthenticationContext/AuthenticationContext.ts
+++ b/front/src/contexts/AuthenticationContext/AuthenticationContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { AuthenticationContextType } from './types';
+
+export const AuthenticationContext = createContext<AuthenticationContextType | null>(null);

--- a/front/src/contexts/AuthenticationContext/AuthenticationContextProvider.tsx
+++ b/front/src/contexts/AuthenticationContext/AuthenticationContextProvider.tsx
@@ -1,0 +1,19 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { AuthenticationContext } from './AuthenticationContext';
+import { useCheckAuthentication } from './useCheckAuthentication';
+
+type AuthenticationContextProviderProps = {
+  children: ReactNode;
+};
+
+export const AuthenticationContextProvider = ({ children }: AuthenticationContextProviderProps) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const { checkAuthentication } = useCheckAuthentication({
+    onSuccess: () => setIsAuthenticated(true),
+    onError: () => setIsAuthenticated(false),
+  });
+
+  const value = useMemo(() => ({ isAuthenticated, checkAuthentication }), [isAuthenticated, checkAuthentication]);
+
+  return <AuthenticationContext.Provider value={value}>{children}</AuthenticationContext.Provider>;
+};

--- a/front/src/contexts/AuthenticationContext/AuthenticationContextProvider.tsx
+++ b/front/src/contexts/AuthenticationContext/AuthenticationContextProvider.tsx
@@ -7,7 +7,7 @@ type AuthenticationContextProviderProps = {
 };
 
 export const AuthenticationContextProvider = ({ children }: AuthenticationContextProviderProps) => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | undefined>();
   const { checkAuthentication } = useCheckAuthentication({
     onSuccess: () => setIsAuthenticated(true),
     onError: () => setIsAuthenticated(false),

--- a/front/src/contexts/AuthenticationContext/types.ts
+++ b/front/src/contexts/AuthenticationContext/types.ts
@@ -1,6 +1,6 @@
 import type { UseCheckAuthenticationReturn } from './useCheckAuthentication';
 
 export type AuthenticationContextType = {
-  isAuthenticated: boolean;
+  isAuthenticated: boolean | undefined;
   checkAuthentication: UseCheckAuthenticationReturn['checkAuthentication'];
 };

--- a/front/src/contexts/AuthenticationContext/types.ts
+++ b/front/src/contexts/AuthenticationContext/types.ts
@@ -1,0 +1,6 @@
+import type { UseCheckAuthenticationReturn } from './useCheckAuthentication';
+
+export type AuthenticationContextType = {
+  isAuthenticated: boolean;
+  checkAuthentication: UseCheckAuthenticationReturn['checkAuthentication'];
+};

--- a/front/src/contexts/AuthenticationContext/useCheckAuthentication.ts
+++ b/front/src/contexts/AuthenticationContext/useCheckAuthentication.ts
@@ -1,0 +1,34 @@
+import { authStatusApi } from '@Front/api/authentication/authStatusApi';
+import type { AuthStatusResponseType } from '@Front/types/Authentication/authStatus/authStatus.types';
+import type { AuthStatusErrorResponse } from '@Front/types/Authentication/authStatus/AuthStatusErrorResponse';
+import { useMutation, type UseMutateAsyncFunction } from '@tanstack/react-query';
+import { useLayoutEffect } from 'react';
+
+type UseCheckAuthenticationProps = {
+  onSuccess: () => void;
+  onError: () => void;
+};
+
+export type UseCheckAuthenticationReturn = {
+  checkAuthentication: UseMutateAsyncFunction<null, AuthStatusErrorResponse, void, unknown>;
+};
+
+export const useCheckAuthentication = ({
+  onSuccess,
+  onError,
+}: UseCheckAuthenticationProps): UseCheckAuthenticationReturn => {
+  const mutation = useMutation<AuthStatusResponseType, AuthStatusErrorResponse>({
+    mutationFn: authStatusApi,
+    retry: false,
+    gcTime: 0,
+    onSuccess,
+    onError,
+  });
+
+  useLayoutEffect(() => {
+    mutation.mutateAsync();
+    // oxlint-disable-next-line exhaustive-deps
+  }, []);
+
+  return { checkAuthentication: mutation.mutateAsync };
+};

--- a/front/src/hooks/useAuthenticationContext.ts
+++ b/front/src/hooks/useAuthenticationContext.ts
@@ -1,5 +1,5 @@
-import { AuthenticationContext } from "@Front/contexts/AuthenticationContext/AuthenticationContext";
-import type { AuthenticationContextType } from "@Front/contexts/AuthenticationContext/types";
-import { useContext } from "react";
+import { AuthenticationContext } from '@Front/contexts/AuthenticationContext/AuthenticationContext';
+import type { AuthenticationContextType } from '@Front/contexts/AuthenticationContext/types';
+import { useContext } from 'react';
 
 export const useAuthenticationContext = () => useContext(AuthenticationContext) as AuthenticationContextType;

--- a/front/src/hooks/useAuthenticationContext.ts
+++ b/front/src/hooks/useAuthenticationContext.ts
@@ -1,0 +1,5 @@
+import { AuthenticationContext } from "@Front/contexts/AuthenticationContext/AuthenticationContext";
+import type { AuthenticationContextType } from "@Front/contexts/AuthenticationContext/types";
+import { useContext } from "react";
+
+export const useAuthenticationContext = () => useContext(AuthenticationContext) as AuthenticationContextType;

--- a/front/src/i18n/@types/resources.ts
+++ b/front/src/i18n/@types/resources.ts
@@ -1,10 +1,12 @@
 import authentication from '../locales/en/authentication.json';
+import dashboard from '../locales/en/dashboard.json';
 import error from '../locales/en/error.json';
 import home from '../locales/en/home.json';
 import signUp from '../locales/en/signUp.json';
 
 const resources = {
   authentication,
+  dashboard,
   error,
   home,
   signUp

--- a/front/src/i18n/locales/en/dashboard.json
+++ b/front/src/i18n/locales/en/dashboard.json
@@ -1,0 +1,3 @@
+{
+  "title": "Dashboard"
+}

--- a/front/src/i18n/locales/en/index.ts
+++ b/front/src/i18n/locales/en/index.ts
@@ -1,10 +1,12 @@
 import enAuthentication from './authentication.json';
+import enDashboard from './dashboard.json';
 import enError from './error.json';
 import enHome from './home.json';
 import enSignUp from './signUp.json';
 
 export const en = {
   home: enHome,
+  dashboard: enDashboard,
   signUp: enSignUp,
   authentication: enAuthentication,
   error: enError,

--- a/front/src/pages/Authentication/OAuth/__tests__/OAuth.test.tsx
+++ b/front/src/pages/Authentication/OAuth/__tests__/OAuth.test.tsx
@@ -6,6 +6,10 @@ import { screen, waitFor } from '@testing-library/react';
 import { oauthProvidersData } from '../constants';
 import { OAuth } from '../index';
 
+beforeAll(() => {
+  server.resetHandlers();
+});
+
 afterEach(() => {
   server.resetHandlers();
 });

--- a/front/src/pages/Authentication/OAuth/__tests__/OAuth.test.tsx
+++ b/front/src/pages/Authentication/OAuth/__tests__/OAuth.test.tsx
@@ -19,14 +19,14 @@ describe('OAuth', () => {
 
   it('renders heading with correct text and aria-labelledby', () => {
     renderOAuth();
-    expect(screen.getByRole('heading', { level: 2, name: 'signInWithProvider' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'authentication.signInWithProvider' })).toBeInTheDocument();
   });
 
   it('renders all OAuth providers as links with correct aria-labels', async () => {
     renderOAuth();
 
     for (const provider of oauthProvidersData) {
-      const link = screen.getByRole('link', { name: provider.ariaLabel });
+      const link = screen.getByRole('link', { name: `authentication.${provider.ariaLabel}` });
       expect(link).toBeInTheDocument();
       await waitFor(() => expect(link).toHaveAttribute('href', oAuthProvidersFixture[provider.id]));
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
@@ -38,7 +38,7 @@ describe('OAuth', () => {
     renderOAuth();
 
     oauthProvidersData.forEach(provider => {
-      const link = screen.getByRole('link', { name: provider.ariaLabel });
+      const link = screen.getByRole('link', { name: `authentication.${provider.ariaLabel}` });
       const icon = link.querySelector('svg');
       expect(icon).toHaveAttribute('aria-hidden');
     });
@@ -54,11 +54,11 @@ describe('OAuth error handling', () => {
     renderOAuth();
 
     oauthProvidersData.forEach(provider => {
-      const link = screen.getByRole('link', { name: provider.ariaLabel });
+      const link = screen.getByRole('link', { name: `authentication.${provider.ariaLabel}` });
       expect(link).toHaveAttribute('href', '#');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
-    expect(await screen.findByText(`error.${oAuthProvidersErrorFixture.code}`)).toBeInTheDocument();
+    expect(await screen.findByText(`authentication.error.${oAuthProvidersErrorFixture.code}`)).toBeInTheDocument();
   });
 });

--- a/front/src/pages/Authentication/SignUp/__tests__/SignUp.test.tsx
+++ b/front/src/pages/Authentication/SignUp/__tests__/SignUp.test.tsx
@@ -30,56 +30,56 @@ describe('SignUp', () => {
   it('renders all form fields, submit button and oauth', () => {
     renderRoute(renderRouteOptions);
 
-    expect(screen.getByLabelText('username')).toBeInTheDocument();
-    expect(screen.getByLabelText('email')).toBeInTheDocument();
-    expect(screen.getByLabelText('password')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'submit' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 2, name: 'signInWithProvider' })).toBeInTheDocument();
+    expect(screen.getByLabelText('signUp.username')).toBeInTheDocument();
+    expect(screen.getByLabelText('signUp.email')).toBeInTheDocument();
+    expect(screen.getByLabelText('signUp.password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'signUp.submit' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'authentication.signInWithProvider' })).toBeInTheDocument();
   });
 
   it('shows validation errors for empty fields', async () => {
     renderRoute(renderRouteOptions);
 
-    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+    await userEvent.click(screen.getByRole('button', { name: 'signUp.submit' }));
 
-    expect(await screen.findByText('requiredUsername')).toBeInTheDocument();
-    expect(screen.getByText('requiredEmail')).toBeInTheDocument();
-    expect(screen.getByText('requiredPassword')).toBeInTheDocument();
+    expect(await screen.findByText('signUp.requiredUsername')).toBeInTheDocument();
+    expect(screen.getByText('signUp.requiredEmail')).toBeInTheDocument();
+    expect(screen.getByText('signUp.requiredPassword')).toBeInTheDocument();
   });
 
   it.each([
     {
       password: '1234567',
-      expectedError: 'minLengthPassword::{"min":8}',
+      expectedError: 'signUp.minLengthPassword::{"min":8}',
       description: 'minimum length error',
     },
     {
       password: '12345678!',
-      expectedError: 'passwordComplexity',
+      expectedError: 'signUp.passwordComplexity',
       description: 'must contain letters error',
     },
     {
       password: 'password1!',
-      expectedError: 'passwordComplexity',
+      expectedError: 'signUp.passwordComplexity',
       description: 'must contain numbers error',
     },
     {
       password: 'Password!',
-      expectedError: 'passwordComplexity',
+      expectedError: 'signUp.passwordComplexity',
       description: 'must contain numbers error',
     },
     {
       password: 'Password1',
-      expectedError: 'passwordComplexity',
+      expectedError: 'signUp.passwordComplexity',
       description: 'must contain symbols error',
     },
   ])('shows password $description', async ({ password, expectedError }) => {
     renderRoute(renderRouteOptions);
 
-    await userEvent.type(screen.getByLabelText('username'), 'testuser');
-    await userEvent.type(screen.getByLabelText('email'), 'test@example.com');
-    await userEvent.type(screen.getByLabelText('password'), password);
-    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+    await userEvent.type(screen.getByLabelText('signUp.username'), 'testuser');
+    await userEvent.type(screen.getByLabelText('signUp.email'), 'test@example.com');
+    await userEvent.type(screen.getByLabelText('signUp.password'), password);
+    await userEvent.click(screen.getByRole('button', { name: 'signUp.submit' }));
 
     expect(await screen.findByText(expectedError)).toBeInTheDocument();
   });
@@ -93,11 +93,11 @@ describe('SignUp error handling', () => {
   it('shows error message on failed submission', async () => {
     renderRoute(renderRouteOptions);
 
-    await userEvent.type(screen.getByLabelText('username'), 'failuser');
-    await userEvent.type(screen.getByLabelText('email'), 'fail@example.com');
-    await userEvent.type(screen.getByLabelText('password'), 'Password1!');
-    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+    await userEvent.type(screen.getByLabelText('signUp.username'), 'failuser');
+    await userEvent.type(screen.getByLabelText('signUp.email'), 'fail@example.com');
+    await userEvent.type(screen.getByLabelText('signUp.password'), 'Password1!');
+    await userEvent.click(screen.getByRole('button', { name: 'signUp.submit' }));
 
-    expect(await screen.findByText(`error.${accountErrorFixture.code}`)).toBeInTheDocument();
+    expect(await screen.findByText(`signUp.error.${accountErrorFixture.code}`)).toBeInTheDocument();
   });
 });

--- a/front/src/pages/Authentication/SignUp/routes.tsx
+++ b/front/src/pages/Authentication/SignUp/routes.tsx
@@ -4,4 +4,7 @@ import { SignUp } from './SignUp';
 export const signUpRoutes: RouteObject = {
   path: 'sign-up',
   element: <SignUp />,
+  handle: {
+    mustBeAuthenticate: false,
+  },
 };

--- a/front/src/pages/Dashboard/Dashboard.tsx
+++ b/front/src/pages/Dashboard/Dashboard.tsx
@@ -1,0 +1,1 @@
+export const Dashboard = () => <h1>Dashboard</h1>;

--- a/front/src/pages/Dashboard/Dashboard.tsx
+++ b/front/src/pages/Dashboard/Dashboard.tsx
@@ -1,1 +1,7 @@
-export const Dashboard = () => <h1>Dashboard</h1>;
+import { useTranslation } from 'react-i18next';
+
+export const Dashboard = () => {
+  const { t } = useTranslation('dashboard');
+
+  return <h1>{t('title')}</h1>;
+};

--- a/front/src/pages/Dashboard/__tests__/Dashboard.test.tsx
+++ b/front/src/pages/Dashboard/__tests__/Dashboard.test.tsx
@@ -10,9 +10,9 @@ const renderRouteOptions: RenderRouteOptions = {
 };
 
 describe('Dashboard', () => {
-  it('shows error message on failed submission', () => {
+  it('renders the dashboard heading', () => {
     renderRoute(renderRouteOptions);
 
-    expect(screen.getByRole('heading', { level: 1, name: 'Dashboard' }));
+    expect(screen.getByRole('heading', { level: 1, name: 'dashboard.title' })).toBeInTheDocument();
   });
 });

--- a/front/src/pages/Dashboard/__tests__/Dashboard.test.tsx
+++ b/front/src/pages/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,0 +1,18 @@
+import { appRoutes } from '@Front/routing/appRoutes';
+import { renderRoute, type RenderRouteOptions } from '@Front/utils/testsUtils/customRender';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { dashboardRoutes } from '../routes';
+
+const renderRouteOptions: RenderRouteOptions = {
+  routes: [dashboardRoutes],
+  routesOptions: { initialEntries: [appRoutes.dashboard()] },
+};
+
+describe('Dashboard', () => {
+  it('shows error message on failed submission', () => {
+    renderRoute(renderRouteOptions);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Dashboard' }));
+  });
+});

--- a/front/src/pages/Dashboard/index.ts
+++ b/front/src/pages/Dashboard/index.ts
@@ -1,0 +1,1 @@
+export { dashboardRoutes } from './routes';

--- a/front/src/pages/Dashboard/routes.tsx
+++ b/front/src/pages/Dashboard/routes.tsx
@@ -4,4 +4,7 @@ import { Dashboard } from './Dashboard';
 export const dashboardRoutes: RouteObject = {
   path: 'dashboard',
   element: <Dashboard />,
+  handle: {
+    mustBeAuthenticate: true,
+  },
 };

--- a/front/src/pages/Dashboard/routes.tsx
+++ b/front/src/pages/Dashboard/routes.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { Dashboard } from './Dashboard';
+
+export const dashboardRoutes: RouteObject = {
+  path: 'dashboard',
+  element: <Dashboard />,
+};

--- a/front/src/pages/Error/__tests__/Error.test.tsx
+++ b/front/src/pages/Error/__tests__/Error.test.tsx
@@ -23,11 +23,13 @@ const renderErrorPage = (message?: string) => {
 describe('ErrorPage', () => {
   it('should display the error message when provided in state', async () => {
     renderErrorPage('TestError');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('error.title');
     expect(await screen.findByRole('alert')).toHaveTextContent('TestError');
   });
 
   it('should display the default unexpected message when no message is provided', async () => {
     renderErrorPage();
-    expect(await screen.findByRole('alert')).toHaveTextContent('unexpected');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('error.title');
+    expect(await screen.findByRole('alert')).toHaveTextContent('error.unexpected');
   });
 });

--- a/front/src/pages/OAuthCallback/OAuthCallback.tsx
+++ b/front/src/pages/OAuthCallback/OAuthCallback.tsx
@@ -1,3 +1,4 @@
+import { appRoutes } from '@Front/routing/appRoutes';
 import { Navigate, useSearchParams } from 'react-router-dom';
 
 export const OAuthCallback = () => {
@@ -5,8 +6,8 @@ export const OAuthCallback = () => {
   const message = searchParams.get('message');
 
   if (message) {
-    return <Navigate to="/error" state={{ message }} replace />;
+    return <Navigate to={appRoutes.error()} state={{ message }} replace />;
   }
 
-  return <Navigate to="/" replace />;
+  return <Navigate to={appRoutes.dashboard()} replace />;
 };

--- a/front/src/pages/OAuthCallback/__tests__/OAuthCallback.test.tsx
+++ b/front/src/pages/OAuthCallback/__tests__/OAuthCallback.test.tsx
@@ -1,5 +1,5 @@
+import { dashboardRoutes } from '@Front/pages/Dashboard';
 import { errorRoutes } from '@Front/pages/Error';
-import { homeRoutes } from '@Front/pages/Home';
 import { appRoutes } from '@Front/routing/appRoutes';
 import { renderRoute } from '@Front/utils/testsUtils/customRender';
 import { screen } from '@testing-library/react';
@@ -8,7 +8,7 @@ import { oauthCallbackRoutes } from '../routes';
 
 const renderOAuthCallback = (message?: string) =>
   renderRoute({
-    routes: [oauthCallbackRoutes, homeRoutes, errorRoutes],
+    routes: [oauthCallbackRoutes, dashboardRoutes, errorRoutes],
     routesOptions: { initialEntries: [appRoutes.oAuthCallback(message)] },
   });
 
@@ -20,6 +20,6 @@ describe('OAuthCallback', () => {
 
   it('should redirect to / when no message param is present', async () => {
     renderOAuthCallback();
-    expect(await screen.findByText('welcome')).toBeInTheDocument();
+    expect(await screen.findByText('dashboard.title')).toBeInTheDocument();
   });
 });

--- a/front/src/providers/withProviders/withProviders.tsx
+++ b/front/src/providers/withProviders/withProviders.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from '@Front/providers/QueryClientProvider';
 import type { ComponentProps, ComponentType } from 'react';
+import { AuthenticationContextProvider } from '../../contexts/AuthenticationContext/AuthenticationContextProvider';
 
 type WithRootProps = {
   queryClient: ComponentProps<typeof QueryClientProvider>['client'];
@@ -8,7 +9,9 @@ type WithRootProps = {
 export const withProvider = <ComponentProps extends object>(Component: ComponentType<ComponentProps>) => {
   const WithProvider = ({ queryClient, ...props }: ComponentProps & WithRootProps) => (
     <QueryClientProvider client={queryClient}>
-      <Component {...(props as ComponentProps)} />
+      <AuthenticationContextProvider>
+        <Component {...(props as ComponentProps)} />
+      </AuthenticationContextProvider>
     </QueryClientProvider>
   );
 

--- a/front/src/routing/appRoutes.ts
+++ b/front/src/routing/appRoutes.ts
@@ -1,9 +1,11 @@
 import { signUpRoutes } from '@Front/pages/Authentication/SignUp';
+import { dashboardRoutes } from '@Front/pages/Dashboard/routes';
 import { errorRoutes } from '@Front/pages/Error';
 import { oauthCallbackRoutes } from '@Front/pages/OAuthCallback';
 
 type AppRoute = {
   home: () => string;
+  dashboard: () => string;
   signUp: () => string;
   oAuthCallback: (message?: string) => string;
   error: () => string;
@@ -11,6 +13,7 @@ type AppRoute = {
 
 export const appRoutes: AppRoute = {
   home: () => '/',
+  dashboard: () => `/${dashboardRoutes.path}`,
   signUp: () => `/${signUpRoutes.path}`,
   oAuthCallback: message => {
     let route = `/${oauthCallbackRoutes.path}`;

--- a/front/src/routing/routes.tsx
+++ b/front/src/routing/routes.tsx
@@ -1,3 +1,4 @@
+import { AuthenticationProtection } from '@Front/components/AuthenticationProtection';
 import { Layout } from '@Front/components/Layout';
 import { authenticationRoutes } from '@Front/pages/Authentication';
 import { dashboardRoutes } from '@Front/pages/Dashboard';
@@ -9,7 +10,11 @@ import type { RouteObject } from 'react-router-dom';
 export const routeObject: RouteObject[] = [
   {
     path: '/',
-    element: <Layout />,
+    element: (
+      <AuthenticationProtection>
+        <Layout />
+      </AuthenticationProtection>
+    ),
     children: [homeRoutes, dashboardRoutes, authenticationRoutes, oauthCallbackRoutes, errorRoutes],
   },
 ];

--- a/front/src/routing/routes.tsx
+++ b/front/src/routing/routes.tsx
@@ -1,5 +1,6 @@
 import { Layout } from '@Front/components/Layout';
 import { authenticationRoutes } from '@Front/pages/Authentication';
+import { dashboardRoutes } from '@Front/pages/Dashboard';
 import { errorRoutes } from '@Front/pages/Error';
 import { homeRoutes } from '@Front/pages/Home';
 import { oauthCallbackRoutes } from '@Front/pages/OAuthCallback';
@@ -9,6 +10,6 @@ export const routeObject: RouteObject[] = [
   {
     path: '/',
     element: <Layout />,
-    children: [homeRoutes, authenticationRoutes, oauthCallbackRoutes, errorRoutes],
+    children: [homeRoutes, dashboardRoutes, authenticationRoutes, oauthCallbackRoutes, errorRoutes],
   },
 ];

--- a/front/src/types/Authentication/authStatus/AuthStatusErrorResponse.ts
+++ b/front/src/types/Authentication/authStatus/AuthStatusErrorResponse.ts
@@ -1,0 +1,4 @@
+import { ErrorResponse } from '@Front/types/ErrorResponse';
+import type { AuthStatusErrorCodeType } from './authStatus.types';
+
+export class AuthStatusErrorResponse extends ErrorResponse<AuthStatusErrorCodeType> {}

--- a/front/src/types/Authentication/authStatus/authStatus.types.ts
+++ b/front/src/types/Authentication/authStatus/authStatus.types.ts
@@ -1,0 +1,5 @@
+import type { ErrorResponseCodeType } from '@Front/types/api.types';
+
+export type AuthStatusResponseType = null;
+
+export type AuthStatusErrorCodeType = ErrorResponseCodeType<'NOT_AUTHENTICATED' | 'TOKEN_INVALID' | 'TOKEN_EXPIRED'>;

--- a/front/src/utils/testsUtils/customRender/index.tsx
+++ b/front/src/utils/testsUtils/customRender/index.tsx
@@ -1,3 +1,5 @@
+import { AuthenticationContextProvider } from '@Front/contexts/AuthenticationContext/AuthenticationContextProvider';
+import { routeObject } from '@Front/routing/routes';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, type RenderOptions } from '@testing-library/react';
 import type { ComponentProps, ReactNode } from 'react';
@@ -9,7 +11,7 @@ export type RenderWithQueryClientOptions = {
 };
 
 export type RenderRouteOptions = {
-  routes: RouteObject[];
+  routes?: RouteObject[];
   routesOptions?: MemoryRouterOpts;
   renderOptions?: Omit<RenderOptions, 'queries'>;
   queryClientProviderOptions?: Partial<ComponentProps<typeof QueryClientProvider>>;
@@ -38,7 +40,7 @@ export const renderWithQueryClient = (
 };
 
 export const renderRoute = ({
-  routes,
+  routes = routeObject,
   routesOptions,
   renderOptions,
   queryClientProviderOptions,
@@ -46,7 +48,9 @@ export const renderRoute = ({
   const router = createMemoryRouter(routes, routesOptions);
 
   return renderWithQueryClient(
-    <RouterProvider router={router} />,
+    <AuthenticationContextProvider>
+      <RouterProvider router={router} />
+    </AuthenticationContextProvider>,
     { queryClientProviderOptions, renderOptions },
   );
 };

--- a/front/vitest.setup.ts
+++ b/front/vitest.setup.ts
@@ -10,9 +10,9 @@ beforeAll(() => {
   server.listen({ onUnhandledRequest: 'error' });
 
   vi.mock('react-i18next', () => ({
-    useTranslation: vi.fn((ressource: string) => ({
+    useTranslation: vi.fn((resource: string) => ({
       t: (messageId: string, args: Record<string, unknown>) =>
-        `${ressource}.${messageId}${args ? `::${JSON.stringify(args)}` : ''}`,
+        `${resource}.${messageId}${args ? `::${JSON.stringify(args)}` : ''}`,
     })),
     initReactI18next: {
       type: '3rdParty',

--- a/front/vitest.setup.ts
+++ b/front/vitest.setup.ts
@@ -10,9 +10,10 @@ beforeAll(() => {
   server.listen({ onUnhandledRequest: 'error' });
 
   vi.mock('react-i18next', () => ({
-    useTranslation: vi.fn().mockReturnValue({
-      t: (messageId: string, args: Record<string, unknown>) => messageId + (args ? `::${JSON.stringify(args)}` : ''),
-    }),
+    useTranslation: vi.fn((ressource: string) => ({
+      t: (messageId: string, args: Record<string, unknown>) =>
+        `${ressource}.${messageId}${args ? `::${JSON.stringify(args)}` : ''}`,
+    })),
     initReactI18next: {
       type: '3rdParty',
       init: () => {},


### PR DESCRIPTION
**Title:** Add authentication protection to routes and implement dashboard page

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
This change introduces authentication checks to route navigation, ensuring users are redirected appropriately based on their authentication status. It also adds a dashboard page and updates related tests and i18n resources.

**Proposed Changes:**
- Add `AuthenticationProtection` component to guard routes based on authentication state.
- Implement authentication context and provider for global state management.
- Create dashboard page and route, including i18n resources.
- Update routing to include dashboard and authentication protection.
- Refactor tests to use new authentication logic and update i18n keys.
- Add API and types for authentication status.
- Update OAuth callback and error handling to use new routes.
- Ensure all relevant components and test utilities use the authentication context.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None