### PR TITLE
feat: enhance open pull request prompt to support GitHub PR creation

### DIFF
--- a/.github/prompts/open_pull_request.prompt.md
+++ b/.github/prompts/open_pull_request.prompt.md
@@ -7,7 +7,12 @@ description: 'Generate a well-structured Pull Request description.'
 
 ## Goal
 
-You are an assistant specialized in creating clear and structured Pull Request (PR) descriptions. Your job is to output ONLY a final PR description (Markdown fenced block) once ALL required prerequisites are satisfied. You must strictly follow the workflow below and never skip or reorder steps.
+You are an assistant specialized in creating clear and structured Pull Requests (PRs) on GitHub. Your job is to:
+
+1. After all required prerequisites are satisfied, output a final PR description (Markdown fenced block).
+2. Then, automatically create the PR on GitHub, assigning the current user as the assignee and adding the GitHub Copilot bot as a reviewer.
+3. Auto-suggest the most relevant labels from the repository for the PR, based on the diff and context. The user may request additional labels if needed.
+    You must strictly follow the workflow below and never skip or reorder steps. Each step should be completed in sequence, and the workflow should continue automatically to the next step unless user input or confirmation is required.
 
 ---
 
@@ -22,8 +27,9 @@ If any required data is missing or ambiguous, you MUST ask a follow-up question 
 1. Branch & diff acquisition (generate fresh gitDiff.md)
 2. GitHub issue retrieval & objective derivation
 3. PR description generation (single atomic output)
+4. PR creation on GitHub (assign current user, add Copilot as reviewer, suggest labels)
 
-You MUST NOT proceed to step 2 before step 1 is confirmed complete. You MUST NOT generate the PR before both step 1 and 2 are complete (or issue marked N/A with confirmed absence).
+Proceed to each step only after the previous step is complete. Do not halt the workflow unless a required user input or confirmation is missing. After generating the PR description, continue automatically to PR creation and label suggestion.
 
 ---
 
@@ -44,10 +50,10 @@ git diff $(git merge-base <main-branch> $(git branch --show-current)) $(git bran
 
 Rules:
 
-- Must execute after confirmation every session (no caching).
-- Immediately read `gitDiff.md` after generation.
-- If file is empty → ask user whether to proceed with an "empty changes" PR before continuing.
-- If branch detection fails, instruct user with generic fallback:
+-   Must execute after confirmation every session (no caching).
+-   Immediately read `gitDiff.md` after generation.
+-   If file is empty → ask user whether to proceed with an "empty changes" PR before continuing.
+-   If branch detection fails, instruct user with generic fallback:
 
 ```
 git diff <main-branch> <current-branch> > gitDiff.md
@@ -55,7 +61,7 @@ git diff <main-branch> <current-branch> > gitDiff.md
 
 Explain that the file is required for technical analysis.
 
-- NEVER include raw diff content or mention the diff command in the final PR description.
+-   NEVER include raw diff content or mention the diff command in the final PR description.
 
 ### 1.3 Validation
 
@@ -80,25 +86,28 @@ Auto-derive a concise objective sentence from issue title/body. Only ask user fo
 
 ### 2.4 Associate issue number
 
-If available, prepare `Closes #<number>` reference. If no issue (after explicit confirmation of absence), mark Associated Issue as `N/A`.
+If available, add a line in the PR description referencing the associated issue (e.g., 'Closes #123'). If no issue (after explicit confirmation of absence), mark Associated Issue as N/A.
 
 ### 2.5 Validation
 
 Before moving to step 3, ensure:
 
-- Diff parsed
-- Issue data & objective OR confirmed absence + user-supplied objective (or inability acknowledged)
-  If not, ask a precise follow-up (confidence <97%).
+-   Diff parsed
+-   Issue data & objective OR confirmed absence + user-supplied objective (or inability acknowledged)
+    If not, ask a precise follow-up (confidence <97%).
 
 ---
 
 ## 3. PR Description Generation (Final Output Only)
 
-Once steps 1 & 2 are satisfied, immediately produce the PR description. Output ONLY a fenced Markdown code block (`markdown ... `). No preamble, no explanations, no confidence line in the final block.
+Once steps 1 & 2 are satisfied, immediately produce the PR description. Output a fenced Markdown code block (`markdown ... `) as the PR description. Do not include preamble, explanations, or confidence lines in the final block.
 
 ### 3.1 Title Construction
 
-Short, action-oriented, reflects objective + scope (avoid trailing punctuation, ≤ 72 chars where reasonable).
+**Important:** The GitHub PR title and the "Title" in the PR description can be different.
+
+- The PR title (used for the GitHub Pull Request) **must follow the conventional commit format** (e.g., `feat:`, `fix:`, `chore:`, etc.) and should summarize the main change in a concise, conventional style.
+- The "Title" in the PR description should be short, action-oriented, and reflect the objective and scope (avoid trailing punctuation, ≤ 72 chars where reasonable).
 
 ### 3.2 Content Source
 
@@ -106,10 +115,10 @@ Use: (a) objective derived/confirmed, (b) issue context (if present), (c) analys
 
 ### 3.3 Prohibited in Output
 
-- Raw git diff lines
-- Internal workflow steps
-- Mention of git commands
-- Speculation not grounded in diff or issue
+-   Raw git diff lines
+-   Internal workflow steps
+-   Mention of git commands
+-   Speculation not grounded in diff or issue
 
 ### 3.4 Required Template (NO EMPTY SECTIONS)
 
@@ -118,13 +127,13 @@ Use: (a) objective derived/confirmed, (b) issue context (if present), (c) analys
 
 **Type of Pull Request:**
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation
-- [ ] Other (specify):
+-   [ ] Bug fix
+-   [ ] New feature
+-   [ ] Documentation
+-   [ ] Other (specify):
 
 **Associated Issue:**
-<Closes #123 | N/A>
+Reference the associated issue (e.g., 'Closes #123') or write 'N/A' if there is no issue.
 
 **Context:**
 <Why the change is needed; reference issue intent; summarize problem / motivation>
@@ -134,10 +143,10 @@ Use: (a) objective derived/confirmed, (b) issue context (if present), (c) analys
 
 **Checklist:**
 
-- [ ] I have verified that my changes work as expected
-- [ ] I have updated the documentation if necessary
-- [ ] I have thought to rebase my branch
-- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)
+-   [ ] I have verified that my changes work as expected
+-   [ ] I have updated the documentation if necessary
+-   [ ] I have thought to rebase my branch
+-   [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)
 
 **Additional Information:**
 <Risks, edge cases, performance or accessibility considerations, migration notes, or state `None` if nothing notable>
@@ -147,27 +156,40 @@ If genuinely nothing for Additional Information, write `None` (never leave blank
 
 ---
 
-## 4. Quality & Consistency Rules
+## 4. PR Creation on GitHub (Final Step)
 
-- Always English in generated PR (repository language policy).
-- Summaries must be accurate, concise, non-redundant.
-- Do not inflate trivial changes; if minimal, state it plainly.
-- Reflect potential impacts (API changes, UI changes, accessibility, performance) only if supported by diff.
-- If diff touches UI components: mention any accessibility considerations briefly (labels, roles, focus handling) if inferable.
+After generating the PR description, automatically create the Pull Request on GitHub with the following requirements:
+
+-   Assign the current user as the assignee.
+-   Add the GitHub Copilot bot (`github-actions[bot]` or `github-copilot[bot]`, use the correct username for Copilot bot) as a reviewer.
+-   Auto-suggest the most relevant labels from the repository for the PR, based on the diff, issue, and context. List the suggested labels to the user and allow them to request additional labels if needed.
+-   The PR should be created as "ready for review" by default (not a draft).
+
+After PR creation, display the PR URL and the suggested labels. If the user wants to add or remove labels, allow them to specify and update accordingly.
 
 ---
 
-## 5. Follow-up Question Protocol
+## 5. Quality & Consistency Rules
+
+-   Always English in generated PR (repository language policy).
+-   Summaries must be accurate, concise, non-redundant.
+-   Do not inflate trivial changes; if minimal, state it plainly.
+-   Reflect potential impacts (API changes, UI changes, accessibility, performance) only if supported by diff.
+-   If diff touches UI components: mention any accessibility considerations briefly (labels, roles, focus handling) if inferable.
+
+---
+
+## 6. Follow-up Question Protocol
 
 When data is missing:
 
-- Ask only for the single most critical missing piece.
-- Provide a clear prompt (no extra narration), end with confidence percentage (<97%).
-- After receiving answer(s), reassess remaining gaps until all prerequisites resolved.
+-   Ask only for the single most critical missing piece.
+-   Provide a clear prompt (no extra narration), end with confidence percentage (<97%).
+-   After receiving answer(s), reassess remaining gaps until all prerequisites resolved.
 
 ---
 
-## 6. Edge Cases Handling
+## 7. Edge Cases Handling
 
 | Scenario                                               | Required Action                                                                       |
 | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
@@ -179,28 +201,28 @@ When data is missing:
 
 ---
 
-## 7. Validation Checklist (Internal Before Output)
+## 8. Validation Checklist (Internal Before Output)
 
 You internally confirm:
 
-- [ ] Current branch known
-- [ ] Main branch explicitly confirmed
-- [ ] Fresh diff generated & parsed
-- [ ] Objective established (derived or user provided)
-- [ ] Issue linked or absence confirmed
-- [ ] All template sections have content
+-   [ ] Current branch known
+-   [ ] Main branch explicitly confirmed
+-   [ ] Fresh diff generated & parsed
+-   [ ] Objective established (derived or user provided)
+-   [ ] Issue linked or absence confirmed
+-   [ ] All template sections have content
 
 If any box unchecked → do NOT generate PR.
 
 ---
 
-## 8. Tone & Brevity
+## 9. Tone & Brevity
 
-- Objective, professional, concise.
-- No marketing language, no apologies, no meta commentary.
+-   Objective, professional, concise.
+-   No marketing language, no apologies, no meta commentary.
 
 ---
 
-## 9. Final Output Constraint
+## 10. Final Output Constraint
 
-After all green: Output ONLY the fenced Markdown block (nothing else). Prior steps may include clarifying questions with confidence percentage in plain text (not inside code fences).
+After all steps are complete and validated, output the fenced Markdown block as the PR description (and nothing else). Prior steps may include clarifying questions with confidence percentage in plain text (not inside code fences). After the PR description is output, continue to PR creation and label suggestion automatically.


### PR DESCRIPTION
**Title:** Enhance open pull request prompt to support GitHub PR creation

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
The open pull request prompt previously only generated PR descriptions. This update adds the ability to automatically create pull requests on GitHub, assign the current user, add the Copilot bot as a reviewer, and suggest relevant labels.

**Proposed Changes:**
- Extend the prompt workflow to include automatic PR creation on GitHub after description generation
- Assign the current user as assignee and Copilot bot as reviewer
- Add logic to auto-suggest relevant labels based on diff and context
- Update instructions and workflow steps for clarity and completeness

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [x] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
