### PR TITLE
feat: update error color for input components

### DIFF
--- a/front/src/assets/css/tokens.css
+++ b/front/src/assets/css/tokens.css
@@ -20,7 +20,7 @@
 
   /* State colors (HSL) */
   --color-focus: var(--color-primary);
-  --color-error: var(--color-accent);
+  --color-error: 0, 100%, 45.1%;
   --color-success: 150, 60%, 45%; /* Harmonious Success Green */
   --color-warning: 45, 100%, 50%; /* Soft Yellow */
 }

--- a/front/src/ui/atoms/Inputs/InputTextAtom/InputTextAtom.scss
+++ b/front/src/ui/atoms/Inputs/InputTextAtom/InputTextAtom.scss
@@ -23,7 +23,7 @@
   }
 
   &[aria-invalid='true'] {
-    --input-shadow-color: hsla(var(--color-error), 0.7);
+    --input-shadow-color: hsl(var(--color-error));
     --input-shadow-size: 2px;
 
     &:hover,


### PR DESCRIPTION
**Title:** Update error color for input components

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
This change updates the error color used in input components to improve visual consistency and accessibility. The previous error color was derived from the accent color; it is now set to a specific HSL value for clarity.

**Proposed Changes:**
- Changed `--color-error` in `tokens.css` to a specific HSL value.
- Updated input error shadow color logic in `InputTextAtom.scss` to use the new HSL value.

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
