### PR TITLE
chore: add missing prettier-plugin-sh package

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -48,6 +48,7 @@
         "nodemon": "^3.1.10",
         "oxlint": "^1.25.0",
         "prettier": "^3.6.2",
+        "prettier-plugin-sh": "^0.18.0",
         "stylelint": "^16.25.0",
         "stylelint-prettier": "^5.0.3",
         "stylelint-webpack-plugin": "^5.0.1",

--- a/front/package.json
+++ b/front/package.json
@@ -64,6 +64,7 @@
     "nodemon": "^3.1.10",
     "oxlint": "^1.25.0",
     "prettier": "^3.6.2",
+    "prettier-plugin-sh": "^0.18.0",
     "stylelint": "^16.25.0",
     "stylelint-prettier": "^5.0.3",
     "stylelint-webpack-plugin": "^5.0.1",


### PR DESCRIPTION
**Title:** Add missing Prettier shell plugin to config

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
The Prettier configuration referenced a shell plugin that was not present in the dependencies. This change adds the missing `prettier-plugin-sh` package to ensure consistency and avoid configuration errors.

**Proposed Changes:**
- Added `prettier-plugin-sh` to `devDependencies` in `front/package.json` and `front/package-lock.json`
- Ensured Prettier configuration matches installed packages

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None