### PR TITLE
chore(back): remove unnecessary provider fields

### DIFF
--- a/back/db/models/account_provider.model.go
+++ b/back/db/models/account_provider.model.go
@@ -10,8 +10,6 @@ type AccountProvider struct {
 	AccountId uuid.UUID          `gorm:"primaryKey;type:uuid;column:account_id" json:"-"`
 	Provider  constants.Provider `gorm:"primaryKey;type:varchar(20);column:provider" json:"provider"`
 	Id        string             `gorm:"type:varchar(100);column:id" json:"-"`
-	Email     *string            `gorm:"type:varchar(100);column:email" json:"-"`
-	Username  string             `gorm:"type:varchar(100);column:username" json:"-"`
 }
 
 func (AccountProvider) TableName() string {

--- a/back/pkg/provider/discord.provider.go
+++ b/back/pkg/provider/discord.provider.go
@@ -61,7 +61,6 @@ func (s *ProviderService) getDiscordUserInfo(code string) (ProviderAccount, erro
 	return ProviderAccount{
 		Id:        userInfo.Id,
 		Username:  userInfo.Username,
-		Email:     nil,
 		AvatarUrl: &pictureUrl,
 	}, nil
 }

--- a/back/pkg/provider/github.provider.go
+++ b/back/pkg/provider/github.provider.go
@@ -10,7 +10,6 @@ import (
 type GithubUserNameInfo struct {
 	Id        int32  `json:"id"`
 	Name      string `json:"login"`
-	Email     string `json:"email"`
 	AvatarUrl string `json:"avatar_url"`
 }
 
@@ -60,7 +59,6 @@ func (s *ProviderService) getGithubUserInfo(code string) (ProviderAccount, error
 	return ProviderAccount{
 		Id:        fmt.Sprintf("%d", userNameInfo.Id),
 		Username:  userNameInfo.Name,
-		Email:     &userNameInfo.Email,
 		AvatarUrl: &userNameInfo.AvatarUrl,
 	}, nil
 }

--- a/back/pkg/provider/google.provider.go
+++ b/back/pkg/provider/google.provider.go
@@ -56,7 +56,6 @@ func (s *ProviderService) getGoogleUserInfo(code string) (ProviderAccount, error
 	return ProviderAccount{
 		Id:        userInfo.Id,
 		Username:  userInfo.Username,
-		Email:     &userInfo.Email,
 		AvatarUrl: &userInfo.Picture,
 	}, nil
 }

--- a/back/pkg/provider/provider.service.go
+++ b/back/pkg/provider/provider.service.go
@@ -96,7 +96,6 @@ func (s *ProviderService) GetProviderUrl(providerEntry, returnUrl string, user *
 type ProviderAccount struct {
 	Id        string
 	Username  string
-	Email     *string
 	AvatarUrl *string
 }
 
@@ -131,16 +130,12 @@ func (s *ProviderService) createProviderAccount(providerUser CreateProviderAccou
 		providerAccountResponse.AccountProvider = &model.AccountProvider{
 			Provider: providerUser.Provider,
 			Id:       providerUser.ProviderAccount.Id,
-			Email:    providerUser.ProviderAccount.Email,
-			Username: providerUser.ProviderAccount.Username,
 		}
 
 		return providerAccountResponse, nil
 	} else if existingAccountProvider.AccountId != uuid.Nil {
 		jwt, err := s.signinService.GenerateToken(&guard.Claims{
-			Id:       existingAccountProvider.AccountId,
-			Username: &existingAccountProvider.Username,
-			Email:    existingAccountProvider.Email,
+			Id: existingAccountProvider.AccountId,
 		})
 		if err != nil {
 			return providerAccountResponse, err
@@ -157,8 +152,6 @@ func (s *ProviderService) createProviderAccount(providerUser CreateProviderAccou
 			{
 				Provider: providerUser.Provider,
 				Id:       providerUser.ProviderAccount.Id,
-				Email:    providerUser.ProviderAccount.Email,
-				Username: providerUser.ProviderAccount.Username,
 			},
 		},
 	}


### PR DESCRIPTION
L'email et le username ont étés retirés de la table `account_provider` dans la base de donnée, car ils ne sont pas nécessaires

L'email n'est plus récoltés via l'appel api pour récupérer les données de l'utilisateur sur les providers.
Le username est récupéré car nous en avons besoin pour définir le username de l'utilisateur à créer.

---

This pull request removes the `Email` and `Username` fields from the `AccountProvider` model and related provider account structures and logic. As a result, the codebase no longer stores or processes user email addresses or usernames for external account providers. The changes affect data models, provider-specific user info handling, and JWT token generation.

### Data model simplification
* Removed the `Email` and `Username` fields from the `AccountProvider` struct in `back/db/models/account_provider.model.go`, streamlining the model and reducing stored user data.

### Provider account structure and processing
* Removed the `Email` field from the `GithubUserNameInfo` struct and stopped assigning email and username values in provider-specific account creation for Discord, GitHub, and Google in their respective provider files. [[1]](diffhunk://#diff-11cde206fd1b3ba7181897029ce5cbecef8a17a511878d00cdd8a68df1e376ffL13) [[2]](diffhunk://#diff-9ff9f196a86df95e5d73c62a6499bc8a6671c3ce70ed0d51be70e532055ed5d7L64) [[3]](diffhunk://#diff-11cde206fd1b3ba7181897029ce5cbecef8a17a511878d00cdd8a68df1e376ffL63) [[4]](diffhunk://#diff-8f96aa5e768f9c3873d4fc4837fb5a15518adb36b0f2bd81c5306be75e7ad520L59)
* Removed the `Email` field from the `ProviderAccount` struct in `back/pkg/provider/provider.service.go`, ensuring consistency across provider account representations.

### JWT and account creation logic
* Removed usage of `Email` and `Username` fields when creating provider accounts and generating JWT tokens, reflecting the updated data model. [[1]](diffhunk://#diff-bd4b152f5c70b895311db3c84ee039b36e9844c6d492b7ec5f1da2890806922fL134-L143) [[2]](diffhunk://#diff-bd4b152f5c70b895311db3c84ee039b36e9844c6d492b7ec5f1da2890806922fL160-L161)