### PR TITLE
fix(back): add missing jwt claims fields on provider login

### DIFF
--- a/back/db/models/account_provider.model.go
+++ b/back/db/models/account_provider.model.go
@@ -8,6 +8,7 @@ import (
 
 type AccountProvider struct {
 	AccountId uuid.UUID          `gorm:"primaryKey;type:uuid;column:account_id" json:"-"`
+	Account   Account            `gorm:"foreignKey:AccountId;references:Id" json:"-"`
 	Provider  constants.Provider `gorm:"primaryKey;type:varchar(20);column:provider" json:"provider"`
 	Id        string             `gorm:"type:varchar(100);column:id" json:"-"`
 }

--- a/back/db/repository/account_providers.repo.go
+++ b/back/db/repository/account_providers.repo.go
@@ -26,7 +26,7 @@ func (*AccountProvidersRepository) Create(accountProvider model.AccountProvider)
 }
 
 func (*AccountProvidersRepository) FindOneById(id string, provider string, accountProvider *model.AccountProvider) error {
-	err := db.GetDB().Where("LOWER(provider) = LOWER(?) AND LOWER(id) = LOWER(?)", provider, id).First(&accountProvider).Error
+	err := db.GetDB().Where("LOWER(provider) = LOWER(?) AND LOWER(id) = LOWER(?)", provider, id).Preload("Account").First(&accountProvider).Error
 	if err != nil {
 		log.Error().Err(err).Msg("ACCOUNT_PROVIDERS_REPOSITORY::FIND_ONE_BY_ID Failed to find account provider")
 	}

--- a/back/pkg/provider/provider.service.go
+++ b/back/pkg/provider/provider.service.go
@@ -135,7 +135,9 @@ func (s *ProviderService) createProviderAccount(providerUser CreateProviderAccou
 		return providerAccountResponse, nil
 	} else if existingAccountProvider.AccountId != uuid.Nil {
 		jwt, err := s.signinService.GenerateToken(&guard.Claims{
-			Id: existingAccountProvider.AccountId,
+			Id:       existingAccountProvider.AccountId,
+			Username: existingAccountProvider.Account.UserName,
+			Email:    existingAccountProvider.Account.Email,
 		})
 		if err != nil {
 			return providerAccountResponse, err


### PR DESCRIPTION
En vrai tout est dans le nom de la pr

---

This pull request enhances the handling of account provider data by improving how related account information is loaded and used throughout the codebase. The main improvements are focused on ensuring that associated account fields are available when working with account providers, which helps provide more complete user information during authentication and other operations.

**Data Model and Query Enhancements:**

* Added an `Account` field to the `AccountProvider` struct and set up the correct GORM foreign key relationship, allowing easy access to related account data.
* Updated the `FindOneById` method in `AccountProvidersRepository` to preload the associated `Account` when fetching an account provider, ensuring that account details are available without additional queries.

**Authentication Improvements:**

* Modified the provider account creation logic in `ProviderService` to include the account's `UserName` and `Email` in the generated JWT claims, providing more complete user information during authentication.