### PR TITLE
chore: add VSCode launch configuration for Makefile

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+    {
+		"label": "make: start",
+		"type": "shell",
+		"command": "make",
+		"args": ["start"]
+	},
+    {
+		"label": "make: build-start",
+		"type": "shell",
+		"command": "make",
+		"args": ["build-start"]
+	},
+    {
+		"label": "make: stop",
+		"type": "shell",
+		"command": "make",
+		"args": ["stop"]
+	},
+    {
+		"label": "make: down",
+		"type": "shell",
+		"command": "make",
+		"args": ["down"]
+	},
+    {
+		"label": "make: clean",
+		"type": "shell",
+		"command": "make",
+		"args": ["clean"]
+	},
+    {
+		"label": "make: logs",
+		"type": "shell",
+		"command": "make",
+		"args": ["logs"]
+	}
+  ]
+}


### PR DESCRIPTION
**Title:** Add VSCode launch configuration for Makefile

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [x] Other (specify): Chore

**Associated Issue:**
Closes #295

**Context:**
VSCode users currently need to manually open a terminal and run `make` to start the project. This change enables a task that can be easier launch in VSCode, streamlining the development workflow and leveraging the existing Makefile setup for Docker-based development.

**Proposed Changes:**
- Add `.vscode/tasks.json` to define VSCode tasks for common Makefile commands (`start`, `build-start`, `stop`, `down`, `clean`, `logs`)
- Allows developers to use VSCode's Run/Debug feature to start the project with a single keypress
- Improves onboarding and daily workflow for contributors using VSCode

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None