### PR TITLE
chore: update workflow triggers to run on all commits to main

### DIFF
--- a/.github/workflows/back-build.yaml
+++ b/.github/workflows/back-build.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'back/**'
-      - '.github/workflows/back-build.yaml'
-      - '.github/actions/setup-go/**'
-      - 'Makefile'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'docker-compose.dev.yml'
-      - 'docker/**'
-      - 'front/Dockerfile'
-      - 'back/Dockerfile'
-      - '.github/workflows/docker-build.yml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/front-build.yaml
+++ b/.github/workflows/front-build.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'front/**'
-      - '.github/workflows/front-build.yaml'
-      - '.github/actions/setup-node/**'
-      - 'Makefile'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:


### PR DESCRIPTION
**Title:** Update workflow triggers to run on all commits to main

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
The change ensures that all workflow files for back-end, front-end, and Docker builds are triggered on every commit to the main branch, regardless of file paths. This improves CI reliability and ensures that all relevant workflows run consistently on main branch updates.

**Proposed Changes:**
- Removed `paths` filters from `push` triggers in `.github/workflows/back-build.yaml`, `.github/workflows/front-build.yaml`, and `.github/workflows/docker-build.yml`.
- Now, any commit pushed to `main` will trigger the respective workflows, not just changes to specific files or directories.
- No changes to workflow logic or job steps.

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
