### PR TITLE
revert: downgrade traefik to 3.6.2 to fix frontend 400 error

### DIFF
--- a/docker/Dockerfile.traefik
+++ b/docker/Dockerfile.traefik
@@ -1,4 +1,4 @@
-FROM traefik:v3.6.4
+FROM traefik:v3.6.2
 
 # Install openssl for certificate generation
 RUN apk add --no-cache openssl


### PR DESCRIPTION
**Title:** Revert Traefik to 3.6.2 to fix frontend 400 error

**Type of Pull Request:**

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Documentation
-   [x] Other (specify): Revert dependency update

**Associated Issue:**
N/A

**Context:**
After upgrading Traefik from version 3.6.2 to 3.6.4, the frontend started returning HTTP 400 errors, preventing it from displaying. This PR reverts the Traefik version to 3.6.2 to resolve the issue while waiting for an upstream fix.

**Proposed Changes:**
- Change Traefik version in `docker/Dockerfile.traefik` from 3.6.4 back to 3.6.2
- Restore previous working state for frontend access

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
