### PR TITLE
chore: use volta node and npm version for development docker

### DIFF
--- a/front/Dockerfile.dev
+++ b/front/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:24-alpine
+FROM marcaureln/volta:2.0.2-bookworm-slim
 
 WORKDIR /app
 

--- a/front/Dockerfile.prod
+++ b/front/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS builder
+FROM marcaureln/volta:2.0.2-bookworm-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
**Title:** Use Volta Node and NPM Versions in Dev Docker

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [x] Other (specify): Chore

**Associated Issue:**
Closes #282

**Context:**
To ensure consistency between local development and CI environments, the development Dockerfiles for the frontend now use the same Node and NPM versions managed by Volta as specified in CI. This addresses discrepancies and potential issues caused by version mismatches.

**Proposed Changes:**
- Updated `front/Dockerfile.dev` and `front/Dockerfile.prod` to use the `marcaureln/volta:2.0.2-bookworm-slim` image instead of the default Node image.
- Aligns local development and production builds with the Node and NPM versions used in CI.
- No application logic or UI changes.

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
