### PR TITLE
chore: set explicit Postgres version 18.1 in Dockerfile

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:18-alpine
+FROM postgres:18.1-alpine
 
 EXPOSE 5432


### PR DESCRIPTION
**Title:** Set explicit Postgres version to 18.1 in Dockerfile

**Type of Pull Request:**

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Documentation
-   [x] Other (specify): Maintenance

**Associated Issue:**
N/A

**Context:**
The Dockerfile for the database previously referenced the generic `postgres:18-alpine` image. Using a more explicit version (`18.1-alpine`) ensures consistent and predictable builds, reducing the risk of unexpected changes from upstream minor version updates.

**Proposed Changes:**
- Updated the `FROM` line in `db/Dockerfile` to use `postgres:18.1-alpine` instead of `postgres:18-alpine`.

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
