### PR TITLE
feat(back): remove username from register dto

### DIFF
--- a/back/docs/docs.go
+++ b/back/docs/docs.go
@@ -618,17 +618,13 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "email",
-                "password",
-                "username"
+                "password"
             ],
             "properties": {
                 "email": {
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
-                },
-                "username": {
                     "type": "string"
                 }
             }

--- a/back/docs/swagger.json
+++ b/back/docs/swagger.json
@@ -610,17 +610,13 @@
             "type": "object",
             "required": [
                 "email",
-                "password",
-                "username"
+                "password"
             ],
             "properties": {
                 "email": {
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
-                },
-                "username": {
                     "type": "string"
                 }
             }

--- a/back/docs/swagger.yaml
+++ b/back/docs/swagger.yaml
@@ -5,12 +5,9 @@ definitions:
         type: string
       password:
         type: string
-      username:
-        type: string
     required:
     - email
     - password
-    - username
     type: object
   account.AccountUpdateDto:
     properties:

--- a/back/pkg/account/account.dto.go
+++ b/back/pkg/account/account.dto.go
@@ -1,7 +1,6 @@
 package account
 
 type AccountCreateDto struct {
-	UserName string `json:"username" binding:"required"`
 	Email    string `json:"email" binding:"required"`
 	Password string `json:"password" binding:"required"`
 }

--- a/back/pkg/account/account.service.go
+++ b/back/pkg/account/account.service.go
@@ -51,15 +51,6 @@ func (s *AccountService) Create(data *AccountCreateDto) (string, error) {
 		return "", constants.ERR_INVALID_EMAIL_FORMAT.Err
 	}
 
-	// Check if username is available
-	isUserNameAvailable, err := s.CheckUserNameAvailability(data.UserName)
-	if err != nil {
-		return "", err
-	}
-	if !isUserNameAvailable {
-		return "", constants.ERR_USERNAME_ALREADY_TAKEN.Err
-	}
-
 	// Check if email already exists
 	var existingAccount model.Account
 	if err := s.accountRepository.FindOneByEmail(data.Email, &existingAccount); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -72,7 +63,6 @@ func (s *AccountService) Create(data *AccountCreateDto) (string, error) {
 	// Create account
 	var account model.Account
 	if err := s.accountRepository.Create(repository.AccountCreateDto{
-		UserName: &data.UserName,
 		Email:    &data.Email,
 		Password: data.Password,
 	}, &account); err != nil {


### PR DESCRIPTION
Le username a été retiré car il est saisi uniquement sur la page "Qui êtes vous ?" et non plus lors du register

This pull request removes the `username` field from the account creation process across the backend codebase. The changes update the data transfer objects, validation, service logic, and API documentation to reflect that `username` is no longer required or handled when creating an account.

**Removal of `username` from account creation:**

* Eliminated the `UserName` field from the `AccountCreateDto` struct in `account.dto.go`, so new accounts no longer require or accept a username.
* Removed all logic related to checking username availability and handling username uniqueness from the `AccountService.Create` method in `account.service.go`.
* Stopped passing `UserName` to the repository layer during account creation in `account.service.go`.

**API documentation updates:**

* Updated the OpenAPI/Swagger definitions in `swagger.yaml`, `swagger.json`, and `docs.go` to remove the `username` property from the account creation schema, and no longer require it for the request. [[1]](diffhunk://#diff-15ce78c87edf60b98a9b360adeaab97b50e6ad0b23aaa271eb950efdf14e3526L8-L13) [[2]](diffhunk://#diff-0ac683f0d3505c4b14d2ddc66de2671d83458d45b1cb9e93dd4c2a84157402c6L613-L624) [[3]](diffhunk://#diff-d8d34fa914962b14ab111ab6ecb00e9ffa3def975d49780d08cd74ebdd8825b8L621-L632)