### PR TITLE
fix(back): remove gorm not found gestion from repositories

### DIFF
--- a/back/db/repository/account.repo.go
+++ b/back/db/repository/account.repo.go
@@ -68,30 +68,27 @@ func (*AccountRepository) Updates(account model.Account) error {
 }
 
 func (*AccountRepository) FindOneById(id uuid.UUID, account *model.Account) error {
-	err := db.GetDB().Where("id = ? AND deleted_at IS NULL", id.String()).Preload("Providers").First(&account).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err := db.GetDB().Where("id = ? AND deleted_at IS NULL", id.String()).Preload("Providers").First(&account).Error; err != nil {
 		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_ID Failed to find account by id")
 		return err
 	}
-	return err
+	return nil
 }
 
 func (*AccountRepository) FindOneByUsername(username string, account *model.Account) error {
-	err := db.GetDB().Where("LOWER(username) = LOWER(?) AND deleted_at IS NULL", username).Preload("Providers").First(&account).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err := db.GetDB().Where("LOWER(username) = LOWER(?) AND deleted_at IS NULL", username).Preload("Providers").First(&account).Error; err != nil {
 		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_USERNAME Failed to find account by username")
 		return err
 	}
-	return err
+	return nil
 }
 
 func (*AccountRepository) FindOneByEmail(email string, account *model.Account) error {
-	err := db.GetDB().Where("LOWER(email) = LOWER(?) AND deleted_at IS NULL", email).Preload("Providers").First(&account).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err := db.GetDB().Where("LOWER(email) = LOWER(?) AND deleted_at IS NULL", email).Preload("Providers").First(&account).Error; err != nil {
 		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_EMAIL Failed to find account by email")
 		return err
 	}
-	return err
+	return nil
 }
 
 func (*AccountRepository) FindOneByEmailOrUsername(emailOrUsername string, account *model.Account) error {


### PR DESCRIPTION
J'ai retiré la vérification de l'erreur du `not found` dans le repository, cette erreur doit être gérée lors de l'appel dans les services
En réalité les services le vérifient déjà (j'ai fait le tour) donc ça fait une double vérification inutile

This pull request refactors error handling in several account repository methods and the sign-in service to use Go's standard `errors.Is` function for more robust error comparison, and simplifies the return logic for repository methods. These changes improve code clarity and reliability when dealing with database record-not-found errors.

**Repository error handling improvements:**

* Refactored `FindOneById`, `FindOneByUsername`, and `FindOneByEmail` methods in `account.repo.go` to use inline error checks and always return `nil` on success, improving readability and consistency.
* Updated error comparison in these methods to use `errors.Is(err, gorm.ErrRecordNotFound)` instead of comparing error strings, making the code more idiomatic and less error-prone.

**Sign-in service error handling:**

* Modified the sign-in logic in `signin.service.go` to use `errors.Is` for checking `gorm.ErrRecordNotFound`, aligning it with Go best practices and ensuring consistent error handling throughout the codebase.