### PR TITLE
feat(back): delete selected slot on reset event status

### DIFF
--- a/back/db/repository/slot.repo.go
+++ b/back/db/repository/slot.repo.go
@@ -55,8 +55,8 @@ func (*SlotRepository) DeleteByEventId(eventId uuid.UUID) error {
 	return nil
 }
 
-// DeleteValidatedByEventId Deletes validated slot by Event ID
-func (r *SlotRepository) DeleteValidatedByEventId(eventId uuid.UUID) error {
+// DeleteValidatedSlotByEventId Deletes validated slot by Event ID
+func (r *SlotRepository) DeleteValidatedSlotByEventId(eventId uuid.UUID) error {
 	if err := db.GetDB().Where("event_id = ? AND is_validated = ?", eventId, true).Delete(&model.Slot{}).Error; err != nil {
 		log.Error().Err(err).Str("eventId", eventId.String()).Msg("SLOT_REPOSITORY::DELETE_VALIDATED_BY_EVENT_ID Failed to delete validated slot by event ID")
 		return err

--- a/back/pkg/event/event.service.go
+++ b/back/pkg/event/event.service.go
@@ -193,7 +193,7 @@ func (s *EventService) Update(eventId uuid.UUID, data *EventUpdateDto, user *gua
 
 	// If status changed, remove validated slot
 	if isStatusChanged {
-		err := s.slotRepository.DeleteValidatedByEventId(event.Id)
+		err := s.slotRepository.DeleteValidatedSlotByEventId(event.Id)
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return err
 		}


### PR DESCRIPTION
Lors du changement du statut d'un event (vers `IN_DECISION` uniquement), le slot validé est supprimé
+ lors du changement de la duration d'un event, les slots sont re-générés