### PR TITLE
ci(back): use vet instead of golangci-lint

### DIFF
--- a/.github/workflows/back-build.yaml
+++ b/.github/workflows/back-build.yaml
@@ -43,12 +43,9 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
-      - name: Run linter
+      - name: Run vet
         working-directory: ${{ env.BACK_FOLDER }}
-        run: golangci-lint run ./... --timeout=5m
+        run: go vet ./...
 
   test:
     name: Test


### PR DESCRIPTION
Go vet est l'outil par défaut qu'utilise golang
Après étude de golangci-lint et son intégration des les IDE j'ai décidé de rester sur l'outil le plus natif et j'ai mis à jour la CI pour utiliser go vet