### PR TITLE
feat(back): generate id before account creation

### DIFF
--- a/back/db/repository/account.repo.go
+++ b/back/db/repository/account.repo.go
@@ -16,6 +16,7 @@ import (
 type AccountRepository struct{}
 
 type AccountCreateDto struct {
+	Id           uuid.UUID
 	UserName     *string
 	Email        *string
 	Color        string
@@ -28,7 +29,7 @@ type AccountCreateDto struct {
 
 func (*AccountRepository) Create(data AccountCreateDto, account *model.Account) error {
 	*account = model.Account{
-		Id:           uuid.New(),
+		Id:           data.Id,
 		UserName:     data.UserName,
 		Email:        data.Email,
 		Color:        data.Color,

--- a/back/pkg/account/account.service.go
+++ b/back/pkg/account/account.service.go
@@ -92,21 +92,16 @@ func (s *AccountService) Create(data *AccountCreateDto) (string, error) {
 
 	// Create account
 	var account model.Account
+	accountId := uuid.New()
 	if err := s.accountRepository.Create(repository.AccountCreateDto{
+		Id:           accountId,
 		Email:        &data.Email,
 		Color:        string(color),
 		Password:     data.Password,
 		Language:     data.Language,
 		TermsVersion: &data.TermsVersion,
+		AvatarUrl:    s.avatarService.GetGravatarURL(accountId.String()),
 	}, &account); err != nil {
-		return "", err
-	}
-
-	// Update avatar
-	if err := s.accountRepository.Updates(model.Account{
-		Id:        account.Id,
-		AvatarUrl: s.avatarService.GetGravatarURL(account.Id.String()),
-	}); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
L'id est désormais généré par le service au lieu de repository
Cela permet d'optimiser les requêtes lors de l'ajout d'une photo de profil sur un nouveau compte

Au lieu de faire 
- Création de compte et retour de l'id
- Génération de l'image grâce à l'id
- Mise à jour du compte via l'id du nouveau compte

On fait
- Génération d'un id
- Génération de l'image grâce à l'id
- Création du compte avec l'image

Résultat : 1 action en base au lieu de 2