### PR TITLE
fix(back): get unique email in oauth and send welcome email

### DIFF
--- a/back/pkg/provider/discord.provider.go
+++ b/back/pkg/provider/discord.provider.go
@@ -10,6 +10,7 @@ import (
 type DiscordUserInfo struct {
 	Id       string `json:"id"`
 	Username string `json:"username"`
+	Email    string `json:"email"`
 	Avatar   string `json:"avatar"`
 }
 
@@ -62,5 +63,6 @@ func (s *ProviderService) getDiscordUserInfo(code string) (ProviderAccount, erro
 		Id:        userInfo.Id,
 		Username:  userInfo.Username,
 		AvatarUrl: &pictureUrl,
+		Email:     &userInfo.Email,
 	}, nil
 }

--- a/back/pkg/provider/github.provider.go
+++ b/back/pkg/provider/github.provider.go
@@ -10,6 +10,7 @@ import (
 type GithubUserNameInfo struct {
 	Id        int32  `json:"id"`
 	Name      string `json:"login"`
+	Email     string `json:"email"`
 	AvatarUrl string `json:"avatar_url"`
 }
 
@@ -60,5 +61,6 @@ func (s *ProviderService) getGithubUserInfo(code string) (ProviderAccount, error
 		Id:        fmt.Sprintf("%d", userNameInfo.Id),
 		Username:  userNameInfo.Name,
 		AvatarUrl: &userNameInfo.AvatarUrl,
+		Email:     &userNameInfo.Email,
 	}, nil
 }

--- a/back/pkg/provider/google.provider.go
+++ b/back/pkg/provider/google.provider.go
@@ -57,5 +57,6 @@ func (s *ProviderService) getGoogleUserInfo(code string) (ProviderAccount, error
 		Id:        userInfo.Id,
 		Username:  userInfo.Username,
 		AvatarUrl: &userInfo.Picture,
+		Email:     &userInfo.Email,
 	}, nil
 }


### PR DESCRIPTION
L'email principal du provider est récupéré afin de l'enregistrer en tant qu'email d'`account` en base.
Si cet email est déjà inscrit, l'erreur existante `ERR_EMAIL_ALREADY_EXISTS` est retournée.

Maintenant qu'on a l'email, le mail de bienvenue est envoyée aussi via la création de compte par OAuth.