### PR TITLE
fix(back): add termsAccepted value in claims on sign in

### DIFF
--- a/back/pkg/signin/signin.service.go
+++ b/back/pkg/signin/signin.service.go
@@ -44,9 +44,10 @@ func (s *SigninService) Signin(data *SigninDto) (token TokenResponseDto, err err
 	}
 
 	claims := &guard.Claims{
-		Id:       account.Id,
-		Username: account.UserName,
-		Email:    account.Email,
+		Id:            account.Id,
+		Username:      account.UserName,
+		Email:         account.Email,
+		TermsAccepted: account.TermsAcceptedAt != nil,
 	}
 
 	return s.GenerateToken(claims)


### PR DESCRIPTION
Fix important lors de la connexion du compte pour ajouter la valeur `TermsAccepted`

Bug observé : lors de la connexion, même quand j'ai déjà coché la case pour accepté les termes, j'obtiens l'erreur API `TERMS_NOT_ACCEPTED`