### PR TITLE
fix: clear toast timeout when manually removed

### DIFF
--- a/front/src/ui/utils/toast/service/toastService/__tests__/toastService.test.ts
+++ b/front/src/ui/utils/toast/service/toastService/__tests__/toastService.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ToastService } from '../toastService';
 
 describe('ToastService', () => {
@@ -113,6 +113,34 @@ describe('ToastService', () => {
     expect(storeAuto.getAllToastIds()).toStrictEqual([]);
 
     unsubscribeAuto();
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  it('should not notify subscribers twice when toast is manually removed before timeout', () => {
+    vi.useFakeTimers();
+
+    const store = new ToastService();
+    const observer = vi.fn();
+    const unsubscribe = store.subscribe(observer);
+
+    store.addToast('Manual', 10000);
+    expect(observer).toHaveBeenCalledTimes(1);
+    const ids = store.getAllToastIds();
+    expect(ids).toHaveLength(1);
+    const toastId = ids[0];
+
+    vi.advanceTimersByTime(100);
+    store.removeToast(toastId);
+    expect(observer).toHaveBeenCalledTimes(2);
+    observer.mockClear();
+
+    vi.advanceTimersByTime(10000);
+    expect(observer).not.toHaveBeenCalled();
+    expect(store.getToastById(toastId)).toBeUndefined();
+    expect(store.getAllToastIds()).toStrictEqual([]);
+    unsubscribe();
+
     vi.useRealTimers();
     vi.clearAllTimers();
   });

--- a/front/src/ui/utils/toast/service/toastService/toastService.ts
+++ b/front/src/ui/utils/toast/service/toastService/toastService.ts
@@ -4,6 +4,7 @@ export type Toast = {
   id: string;
   message: string;
   duration?: number;
+  timeout: ReturnType<typeof setTimeout>;
 };
 
 export class ToastService extends AbstractObserver {
@@ -24,17 +25,18 @@ export class ToastService extends AbstractObserver {
 
     const durationToUse = duration || this.defaultDuration;
 
+    const timeout = setTimeout(() => {
+      this.removeToast(newId);
+    }, durationToUse);
+
     this.toast.set(newId, {
       id: newId,
       message: toast,
       duration: durationToUse,
+      timeout,
     });
 
     this.cachedAllToastIds = Array.from(this.toast.keys());
-
-    setTimeout(() => {
-      this.removeToast(newId);
-    }, durationToUse);
 
     this.notifyObservers();
   }
@@ -48,6 +50,11 @@ export class ToastService extends AbstractObserver {
   }
 
   removeToast(id: string) {
+    const toast = this.toast.get(id);
+    if (toast) {
+      clearTimeout(toast.timeout);
+    }
+
     this.toast.delete(id);
 
     this.cachedAllToastIds = Array.from(this.toast.keys());


### PR DESCRIPTION
**Type of Pull Request:**

-   [x] Bug fix
-   [ ] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
Previously `ToastService` scheduled automatic removal of toasts via `setTimeout`, but did not store or clear that timer when a toast was removed manually. This could cause subscribers to be notified again when the original timeout fired. The change ensures timers are tracked and cleared on manual removal. A new unit test verifies the corrected behavior.

**Proposed Changes:**
- Added a `timeout` property to the `Toast` type and store the `setTimeout` handle when creating a toast.
- Clear the stored timeout in `removeToast()` before deleting the toast to avoid double notifications.
- Removed the previous anonymous `setTimeout` call and replaced it with a tracked timer.
- Added a unit test `should not notify subscribers twice when toast is manually removed before timeout` to `front/src/ui/utils/toast/service/toastService/__tests__/toastService.test.ts` to assert correct subscriber behavior.
- Files changed:
  - `front/src/ui/utils/toast/service/toastService/toastService.ts`
  - `front/src/ui/utils/toast/service/toastService/__tests__/toastService.test.ts`

**Checklist:**

-   [ ] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [ ] I have thought to rebase my branch
-   [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
- Risks: Low — change is localized to toast lifecycle management but touches public `Toast` type shape; TypeScript consumers should compile-check.
- Accessibility: None
- Performance: Negligible (clearing timers reduces unnecessary callbacks).
- Migration notes: None