### PR TITLE
feat: add NumberInputAtom component to UI toolkit

### DIFF
--- a/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.mdx
+++ b/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.mdx
@@ -1,0 +1,85 @@
+import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
+import * as NumberInputAtomStories from './NumberInputAtom.stories';
+
+<Meta of={NumberInputAtomStories} />
+
+# NumberInputAtom
+
+A reusable, accessible number input atom for forms and UI elements.
+
+## Usage
+
+```tsx
+<NumberInputAtom
+  name="input-name"
+  placeholder="Enter a number"
+  value={value}
+  onChange={handleChange}
+  className="custom-class"
+/>
+```
+
+## Props
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Required</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>name</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+        <strong>Yes</strong>
+      </td>
+      <td>Input name attribute for form identification</td>
+    </tr>
+    <tr>
+      <td>
+        <code>className</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>No</td>
+      <td>Custom class for styling</td>
+    </tr>
+    <tr>
+      <td>
+        <code>...props</code>
+      </td>
+      <td>
+        <code>input props (HTMLInput)</code>
+      </td>
+      <td>No</td>
+      <td>All standard input props (e.g. value, onChange, placeholder)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Accessibility
+
+- Follows WCAG 2.2 AA and RGAA 4 guidelines.
+- Keyboard accessible.
+- Use with a `<label htmlFor>` for best accessibility.
+
+## Example
+
+```tsx
+<label htmlFor="my-input">Label</label>
+<NumberInputAtom name="my-input" id="my-input" placeholder="Enter a number" />
+```
+
+## Playground
+
+<Canvas of={NumberInputAtomStories.Default} sourceState="shown" />
+<Controls of={NumberInputAtomStories.Default} />

--- a/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.scss
+++ b/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.scss
@@ -1,0 +1,5 @@
+@use '../../../../assets/css/inputs' as *;
+
+.ds-number-input-atom {
+  @extend %input-base;
+}

--- a/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.stories.tsx
+++ b/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from 'storybook-react-rsbuild';
+
+import { NumberInputAtom } from './NumberInputAtom';
+
+const meta = {
+  title: 'Atoms/Inputs/NumberInputAtom',
+  component: NumberInputAtom,
+  args: { name: 'number-input', placeholder: 'Enter a number', className: 'custom-class' },
+  argTypes: {
+    'aria-invalid': {
+      control: { type: 'boolean' },
+    },
+    onChange: { action: true, table: { disable: true } },
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof NumberInputAtom>;
+
+export default meta;
+
+export const Default: StoryObj<typeof meta> = {
+  args: {
+    min: 0,
+    max: 100,
+    step: 5,
+  },
+};
+
+export const Invalid: StoryObj<typeof meta> = {
+  args: {
+    'aria-invalid': 'true',
+  },
+};

--- a/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.tsx
+++ b/front/src/ui/atoms/Inputs/NumberInputAtom/NumberInputAtom.tsx
@@ -1,0 +1,17 @@
+import { getClassName } from '@Front/utils/getClassName';
+import type { ComponentPropsWithRef } from 'react';
+
+import './NumberInputAtom.scss';
+
+type NumberInputAtomProps = Omit<ComponentPropsWithRef<'input'>, 'name'> & {
+  name: string;
+};
+
+export const NumberInputAtom = ({ className, ...props }: NumberInputAtomProps) => {
+  const parentClassName = getClassName({
+    defaultClassName: 'ds-number-input-atom',
+    className,
+  });
+
+  return <input className={parentClassName} type="number" {...props} />;
+};

--- a/front/src/ui/atoms/Inputs/NumberInputAtom/__tests__/NumberInputAtom.test.tsx
+++ b/front/src/ui/atoms/Inputs/NumberInputAtom/__tests__/NumberInputAtom.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { NumberInputAtom } from '../NumberInputAtom';
+
+describe('NumberInputAtom', () => {
+  it('should render an input of type number with required name prop', () => {
+    render(<NumberInputAtom name="test-input" placeholder="Enter text" />);
+    const input = screen.getByRole('spinbutton');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'number');
+    expect(input).toHaveAttribute('name', 'test-input');
+    expect(input).toHaveClass('ds-number-input-atom');
+    expect(input).toHaveAttribute('placeholder', 'Enter text');
+  });
+
+  it('should apply custom className', () => {
+    render(<NumberInputAtom name="test-input" className="custom-class" />);
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveClass('ds-number-input-atom custom-class');
+  });
+});


### PR DESCRIPTION
**Title:** Add NumberInputAtom component to UI toolkit

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
Closes #681

**Context:**
A new, reusable, and accessible number input atom is needed for forms and UI elements in the front-end toolkit, as described in the associated issue.

**Proposed Changes:**
- Added `NumberInputAtom` React component with required `name` prop and support for standard input props.
- Created SCSS file for consistent styling using the design system's input base.
- Added Storybook stories and MDX documentation for usage, props, and accessibility.
- Provided unit tests to verify rendering, props, and className application.

**Checklist:**

-   [ ] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [ ] I have thought to rebase my branch
-   [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
