### PR TITLE
fix(back): sign in dto error

### DIFF
--- a/back/pkg/signin/signin.controller.go
+++ b/back/pkg/signin/signin.controller.go
@@ -32,9 +32,7 @@ func NewSigninController(ctl *SigninController) *SigninController {
 // @Router /api/v1/auth/signin [post]
 func (ctl *SigninController) Signin(c *gin.Context) {
 	var data SigninDto
-	err := helpers.SetHttpContextBody(c, &data)
-	if err != nil {
-		helpers.HandleJSONResponse(c, nil, err)
+	if err := helpers.SetHttpContextBody(c, &data); err != nil {
 		return
 	}
 


### PR DESCRIPTION
Deux erreurs étaient renvoyés sur ce controlleur quand le DTO n'était pas correct

Fixé pour être conforme aux autre controlleurs
