### PR TITLE
fix(back): auth logout guard

### DIFF
--- a/back/server/router.go
+++ b/back/server/router.go
@@ -56,11 +56,11 @@ func NewRouter() *gin.Engine {
 
 			authGroup.POST("/signin", signinRouter.Signin)
 
-			authGroup.Use(guard.AuthCheck(&guard.AuthCheckParams{RequireAuthentication: false, RequireCompleteProfile: true})).GET("/:provider/url", providerRouter.ProviderUrl)
+			authGroup.GET("/:provider/url", guard.AuthCheck(&guard.AuthCheckParams{RequireAuthentication: false, RequireCompleteProfile: true}), providerRouter.ProviderUrl)
 			authGroup.GET("/:provider/callback", providerRouter.ProviderCallback)
 
-			authGroup.Use(guard.AuthCheck(nil)).GET("/status", authRouter.Status)
-			authGroup.Use(guard.AuthCheck(nil)).POST("/logout", authRouter.Logout)
+			authGroup.GET("/status", guard.AuthCheck(nil), authRouter.Status)
+			authGroup.POST("/logout", guard.AuthCheck(&guard.AuthCheckParams{RequireAuthentication: true, RequireCompleteProfile: false}), authRouter.Logout)
 
 		}
 


### PR DESCRIPTION
# Bug

Réception d'une `403` sur `POST` `{{apiUrl}}/{{apiVersion}}/auth/logout` si l'utilisateur se déconnecte et n'a pas encore complété son profil

```json
{
  "code": "USERNAME_MISSING"
}
```

# Modifications

Comme déjà effectué sur les autres groupes du router, j'ai retiré le `Use` qui agit sur tout le groupe au lieu de la route concernée uniquement

J'ai donc mis le déclenchement des guard directement dans la méthode du verbe HTTP

# Résultat

J'obtiens une `200`