### PR TITLE
chore: remove last husky remnants

### DIFF
--- a/.github/workflows/back-build.yaml
+++ b/.github/workflows/back-build.yaml
@@ -11,7 +11,6 @@ on:
     branches: ["main"]
 
 env:
-  HUSKY: 0
   BACK_FOLDER: ./back
 
 jobs:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,7 +11,6 @@ on:
       - .github/workflows/copilot-setup-steps.yml
 
 env:
-  HUSKY: 0
   FRONT_FOLDER: ./front
 
 jobs:

--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,4 +1,3 @@
-husky
 build
 coverage
 node_modules


### PR DESCRIPTION
**Title:** Remove Husky remnants

**Type of Pull Request:**

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Documentation
-   [x] Other (specify): CI/CD maintenance

**Associated Issue:**
N/A

**Context:**
This PR removes the last remaining references and files related to Husky, which is no longer used in the project.

**Proposed Changes:**
- Remove obsolete Husky-related environment variables from workflow files.
- Delete the `husky` entry from `.dockerignore` in the `front` directory.

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [ ] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
