### PR TITLE
feat(ClickIcon): create ClickIcon component with styles and stories

### DIFF
--- a/front/src/ui/molecules/ClickIcon/ClickIcon.mdx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.mdx
@@ -45,6 +45,16 @@ A reusable ClickIcon molecule for Ui elements.
       <td>No</td>
       <td>Custom class for styling</td>
     </tr>
+    <tr>
+      <td>
+        <code>props</code>
+      </td>
+      <td>
+        <code>native button element props</code>
+      </td>
+      <td>No</td>
+      <td>props of the native button</td>
+    </tr>
   </tbody>
 </table>
 
@@ -62,5 +72,3 @@ import GoogleIcon from '@Front/assets/svg/google_icon.svg?react';
 
 <Canvas of={ClickIconStories.Default} sourceState="shown" />
 <Controls of={ClickIconStories.Default} />
-
-

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.mdx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.mdx
@@ -1,0 +1,66 @@
+import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
+import * as ClickIconStories from './ClickIcon.stories';
+
+<Meta of={ClickIconStories} />
+
+# ClickIcon
+
+A reusable ClickIcon molecule for Ui elements.
+
+## Usage
+
+```tsx
+<ClickIcon icon={GoogleIcon} />
+```
+
+## Props
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Required</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>icon</code>
+      </td>
+      <td>
+        <code>SVGIcon</code>
+      </td>
+      <td>Yes</td>
+      <td>The icon</td>
+    </tr>
+    <tr>
+      <td>
+        <code>className</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>No</td>
+      <td>Custom class for styling</td>
+    </tr>
+  </tbody>
+</table>
+
+## Example
+
+```tsx
+import SendIcon from '@material-symbols/svg-400/outlined/send.svg?react';
+import GoogleIcon from '@Front/assets/svg/google_icon.svg?react';
+
+<ClickIcon icon={SendIcon} />
+<ClickIcon icon={GoogleIcon} className="custom className" />
+```
+
+## Playground
+
+<Canvas of={ClickIconStories.Default} sourceState="shown" />
+<Controls of={ClickIconStories.Default} />
+
+

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.scss
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.scss
@@ -1,9 +1,19 @@
+@use '../../../utils/sass/mixins/helpers';
+@use '../../../utils/sass/mixins/responsive';
+
 .ds-click-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   border: none;
   background: none;
   padding: 0;
   cursor: pointer;
+  --icon-size: #{helpers.px-to-rem(20)};
+
+  .ds-icon {
+    width: var(--icon-size);
+    height: var(--icon-size);
+  }
+
+  @include responsive.media-exceeds-width('desktop-small') {
+    --icon-size: #{helpers.px-to-rem(24)};
+  }
 }

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.scss
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.scss
@@ -2,10 +2,11 @@
 @use '../../../utils/sass/mixins/responsive';
 
 .ds-click-icon {
+  padding: 0;
   border: none;
   background: none;
-  padding: 0;
   cursor: pointer;
+
   --icon-size: #{helpers.px-to-rem(20)};
 
   .ds-icon {

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.scss
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.scss
@@ -1,0 +1,9 @@
+.ds-click-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
@@ -15,7 +15,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     icon: SendIcon,
-    className: 'custom-class',
-    onClick: () => alert('Icon clicked!'),
+    onClick: { action: true, table: { disable: true } },
   },
 };

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
@@ -1,0 +1,21 @@
+import SendIcon from '@material-symbols/svg-400/outlined/send.svg?react';
+import type { Meta, StoryObj } from 'storybook-react-rsbuild';
+
+import { ClickIcon } from './ClickIcon';
+
+const meta = {
+  title: 'Molecules/ClickIcon',
+  component: ClickIcon,
+} satisfies Meta<typeof ClickIcon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    icon: SendIcon,
+    className: 'custom-class',
+    onClick: () => alert('Icon clicked!'),
+  },
+};

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   component: ClickIcon,
   argTypes: {
     onClick: { action: true, table: { disable: true } },
+    className: { control: 'text' },
   },
 } satisfies Meta<typeof ClickIcon>;
 

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.stories.tsx
@@ -6,6 +6,9 @@ import { ClickIcon } from './ClickIcon';
 const meta = {
   title: 'Molecules/ClickIcon',
   component: ClickIcon,
+  argTypes: {
+    onClick: { action: true, table: { disable: true } },
+  },
 } satisfies Meta<typeof ClickIcon>;
 
 export default meta;
@@ -15,6 +18,5 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     icon: SendIcon,
-    onClick: { action: true, table: { disable: true } },
   },
 };

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.tsx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.tsx
@@ -1,0 +1,24 @@
+// oxlint-disable react/jsx-props-no-spreading
+import { Icon, type SvgIcon } from '@Front/ui/atoms/Icon/Icon';
+import { getClassName } from '@Front/utils/getClassName';
+import type { ComponentPropsWithoutRef } from 'react';
+
+import './ClickIcon.scss';
+
+type IconProps = {
+  icon: SvgIcon;
+  className?: string;
+} & ComponentPropsWithoutRef<'button'>;
+
+export const ClickIcon = ({ icon, className, ...props }: IconProps) => {
+  const parentClassName = getClassName({
+    defaultClassName: 'ds-click-icon',
+    className: className,
+  });
+
+  return (
+    <button className={parentClassName} {...props}>
+      <Icon icon={icon} />
+    </button>
+  );
+};

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.tsx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.tsx
@@ -9,10 +9,10 @@ type IconProps = {
   icon: SvgIcon;
 } & ComponentPropsWithoutRef<'button'>;
 
-export const ClickIcon = ({ icon, ...props }: IconProps) => {
+export const ClickIcon = ({ icon, className, ...props }: IconProps) => {
   const parentClassName = getClassName({
     defaultClassName: 'ds-click-icon',
-    className: props.className,
+    className: className,
   });
 
   return (

--- a/front/src/ui/molecules/ClickIcon/ClickIcon.tsx
+++ b/front/src/ui/molecules/ClickIcon/ClickIcon.tsx
@@ -7,13 +7,12 @@ import './ClickIcon.scss';
 
 type IconProps = {
   icon: SvgIcon;
-  className?: string;
 } & ComponentPropsWithoutRef<'button'>;
 
-export const ClickIcon = ({ icon, className, ...props }: IconProps) => {
+export const ClickIcon = ({ icon, ...props }: IconProps) => {
   const parentClassName = getClassName({
     defaultClassName: 'ds-click-icon',
-    className: className,
+    className: props.className,
   });
 
   return (

--- a/front/src/ui/molecules/ClickIcon/__tests__/ClickIcon.test.tsx
+++ b/front/src/ui/molecules/ClickIcon/__tests__/ClickIcon.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import { ClickIcon } from '../ClickIcon';
+
+describe('ClickIcon', () => {
+  it('renders the icon correctly', () => {
+    render(
+      <ClickIcon
+        icon={props => (
+          <svg {...props}>
+            <rect width="100" height="100" fill="blue" />
+          </svg>
+        )}
+      />,
+    );
+  });
+
+  it('applies the custom class name', () => {
+    const { container } = render(
+      <ClickIcon
+        icon={props => (
+          <svg {...props}>
+            <rect width="100" height="100" fill="blue" />
+          </svg>
+        )}
+        className="custom-class"
+      />,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+});

--- a/front/src/ui/molecules/ClickIcon/__tests__/ClickIcon.test.tsx
+++ b/front/src/ui/molecules/ClickIcon/__tests__/ClickIcon.test.tsx
@@ -2,18 +2,6 @@ import { render } from '@testing-library/react';
 import { ClickIcon } from '../ClickIcon';
 
 describe('ClickIcon', () => {
-  it('renders the icon correctly', () => {
-    render(
-      <ClickIcon
-        icon={props => (
-          <svg {...props}>
-            <rect width="100" height="100" fill="blue" />
-          </svg>
-        )}
-      />,
-    );
-  });
-
   it('applies the custom class name', () => {
     const { container } = render(
       <ClickIcon
@@ -26,5 +14,22 @@ describe('ClickIcon', () => {
       />,
     );
     expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('applies props to the button element', () => {
+    const onClick = vitest.fn();
+    const { getByRole } = render(
+      <ClickIcon
+        icon={props => (
+          <svg {...props}>
+            <rect width="100" height="100" fill="blue" />
+          </svg>
+        )}
+        onClick={onClick}
+      />,
+    );
+    const button = getByRole('button');
+    button.click();
+    expect(onClick).toHaveBeenCalled();
   });
 });

--- a/front/src/ui/molecules/ClickIcon/__tests__/ClickIcon.test.tsx
+++ b/front/src/ui/molecules/ClickIcon/__tests__/ClickIcon.test.tsx
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ClickIcon } from '../ClickIcon';
 
 describe('ClickIcon', () => {
   it('applies the custom class name', () => {
-    const { container } = render(
+    render(
       <ClickIcon
         icon={props => (
           <svg {...props}>
@@ -13,12 +13,13 @@ describe('ClickIcon', () => {
         className="custom-class"
       />,
     );
-    expect(container.firstChild).toHaveClass('custom-class');
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('custom-class');
   });
 
   it('applies props to the button element', () => {
     const onClick = vitest.fn();
-    const { getByRole } = render(
+    render(
       <ClickIcon
         icon={props => (
           <svg {...props}>
@@ -28,7 +29,7 @@ describe('ClickIcon', () => {
         onClick={onClick}
       />,
     );
-    const button = getByRole('button');
+    const button = screen.getByRole('button');
     button.click();
     expect(onClick).toHaveBeenCalled();
   });


### PR DESCRIPTION
Add a reusable ClickIcon component with associated styles and Storybook stories. Include props for icon and custom class name. Implement tests for rendering and class application.