### PR TITLE
feat: create Modal organism component

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,28 +5,40 @@
       "label": "make: start",
       "type": "shell",
       "command": "bash",
-      "args": ["-c", "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make start"],
+      "args": [
+        "-c",
+        "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make start"
+      ],
       "problemMatcher": []
     },
     {
       "label": "make: front",
       "type": "shell",
       "command": "bash",
-      "args": ["-c", "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make front"],
+      "args": [
+        "-c",
+        "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make front"
+      ],
       "problemMatcher": []
     },
     {
       "label": "make: back",
       "type": "shell",
       "command": "bash",
-      "args": ["-c", "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make back"],
+      "args": [
+        "-c",
+        "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make back"
+      ],
       "problemMatcher": []
     },
     {
       "label": "make: storybook",
       "type": "shell",
       "command": "bash",
-      "args": ["-c", "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make storybook"],
+      "args": [
+        "-c",
+        "f(){ kill 0; }; trap f SIGTERM SIGINT EXIT; make storybook"
+      ],
       "problemMatcher": []
     },
     {

--- a/front/src/ui/atoms/Card/Card.tsx
+++ b/front/src/ui/atoms/Card/Card.tsx
@@ -1,15 +1,14 @@
 // oxlint-disable react/jsx-props-no-spreading
-// oxlint-disable id-length
 import { getClassName } from '@Front/utils/getClassName';
 import type { ComponentPropsWithoutRef, ElementType } from 'react';
 import './Card.scss';
 
-type CardProps<T extends ElementType = 'div'> = {
-  as?: T;
-} & ComponentPropsWithoutRef<T>;
+type CardProps<As extends ElementType = 'div'> = {
+  as?: As;
+} & ComponentPropsWithoutRef<As>;
 
-export const Card = <T extends ElementType = 'div'>({ as, className, children, ...props }: CardProps<T>) => {
-  const Component = as ?? 'div';
+export const Card = <As extends ElementType = 'div'>({ as, className, children, ...props }: CardProps<As>) => {
+  const Component = as || 'div';
 
   const parentClassName = getClassName({
     defaultClassName: 'ds-card',

--- a/front/src/ui/atoms/Card/Card.tsx
+++ b/front/src/ui/atoms/Card/Card.tsx
@@ -1,3 +1,5 @@
+// oxlint-disable react/jsx-props-no-spreading
+// oxlint-disable id-length
 import { getClassName } from '@Front/utils/getClassName';
 import type { ComponentPropsWithoutRef, ElementType } from 'react';
 import './Card.scss';

--- a/front/src/ui/atoms/Card/Card.tsx
+++ b/front/src/ui/atoms/Card/Card.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable react/jsx-props-no-spreading
 import { getClassName } from '@Front/utils/getClassName';
 import type { ComponentPropsWithoutRef, ElementType } from 'react';
 import './Card.scss';

--- a/front/src/ui/atoms/Card/Card.tsx
+++ b/front/src/ui/atoms/Card/Card.tsx
@@ -1,6 +1,5 @@
 import { getClassName } from '@Front/utils/getClassName';
-import { type ComponentPropsWithoutRef, type ElementType } from 'react';
-
+import type { ComponentPropsWithoutRef, ElementType } from 'react';
 import './Card.scss';
 
 type CardProps<T extends ElementType = 'div'> = {

--- a/front/src/ui/molecules/Button/Button.stories.tsx
+++ b/front/src/ui/molecules/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from 'storybook-react-rsbuild';
-import SendIcon from '@material-symbols/svg-400/outlined/send.svg?react';
+import PaletteIcon from '@material-symbols/svg-400/outlined/palette.svg?react';
 import { Button } from './Button';
 
 const meta = {
@@ -33,7 +33,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: args => (
-    <Button {...args} icon={SendIcon}>
+    <Button {...args} icon={PaletteIcon}>
       {args.children}
     </Button>
   ),

--- a/front/src/ui/organisms/modal/Modal.mdx
+++ b/front/src/ui/organisms/modal/Modal.mdx
@@ -30,7 +30,7 @@ const Example = () => {
           onClick: closeModal,
         }}
         secondaryButtonProps={{
-          children: 'Close'
+          children: 'Close',
         }}
       >
         Modal's content
@@ -124,8 +124,8 @@ The component is designed to be controlled with a dialog ref (for example via `u
       </td>
       <td>No</td>
       <td>
-        Native dialog props (for example <code>onClose</code>, <code>open</code>, <code>aria-*</code>). The
-        component also sets <code>closedby="any"</code> on the native dialog element.
+        Native dialog props (for example <code>onClose</code>, <code>open</code>, <code>aria-*</code>). The component
+        also sets <code>closedby="any"</code> on the native dialog element.
       </td>
     </tr>
   </tbody>

--- a/front/src/ui/organisms/modal/Modal.mdx
+++ b/front/src/ui/organisms/modal/Modal.mdx
@@ -1,0 +1,143 @@
+import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
+import * as ModalStories from './Modal.stories';
+
+<Meta of={ModalStories} />
+
+# Modal
+
+A reusable dialog component built on top of the native HTML `<dialog>` element for confirmation flows and focused interactions.
+
+## Usage
+
+```tsx
+import { useModal } from '@Front/ui/utils/hooks/useModal';
+import { Modal } from '@Front/ui/organisms/modal/Modal';
+
+const Example = () => {
+  const { modalRef, openModal, closeModal } = useModal();
+
+  return (
+    <>
+      <button type="button" onClick={openModal}>
+        Open Modal
+      </button>
+
+      <Modal
+        ref={modalRef}
+        title="Modal title"
+        primaryButtonProps={{
+          children: 'Action',
+          onClick: closeModal,
+        }}
+        secondaryButtonProps={{
+          children: 'Close'
+        }}
+      >
+        Modal's content
+      </Modal>
+    </>
+  );
+};
+```
+
+The component is designed to be controlled with a dialog ref (for example via `useModal`).
+
+## Props
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Required</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>title</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+        <strong>Yes</strong>
+      </td>
+      <td>
+        Modal heading text, linked to the dialog through <code>aria-labelledby</code>.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>children</code>
+      </td>
+      <td>
+        <code>ReactNode</code>
+      </td>
+      <td>
+        <strong>Yes</strong>
+      </td>
+      <td>Content rendered inside the modal body.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>primaryButtonProps</code>
+      </td>
+      <td>
+        <code>Omit&lt;ComponentProps&lt;typeof Button&gt;, 'className'&gt;</code>
+      </td>
+      <td>
+        <strong>Yes</strong>
+      </td>
+      <td>Props forwarded to the primary footer action button.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>secondaryButtonProps</code>
+      </td>
+      <td>
+        <code>Omit&lt;ComponentProps&lt;typeof Button&gt;, 'className'&gt;</code>
+      </td>
+      <td>No</td>
+      <td>
+        Optional props for a secondary footer action button (typically close/cancel). Its visual variant is always
+        forced to <code>secondary</code> by the component.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>className</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>No</td>
+      <td>Additional class applied to the root dialog element.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>...props</code>
+      </td>
+      <td>
+        <code>DialogHTMLAttributes&lt;HTMLDialogElement&gt;</code>
+      </td>
+      <td>No</td>
+      <td>
+        Native dialog props (for example <code>onClose</code>, <code>open</code>, <code>aria-*</code>). The
+        component also sets <code>closedby="any"</code> on the native dialog element.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Accessibility
+
+- Uses a native `<dialog>` element and links the title to the dialog with <code>aria-labelledby</code>.
+- Includes a header close icon button and an optional footer secondary action for closing flows.
+- All actions are keyboard-operable through native button semantics.
+
+## Playground
+
+<Canvas of={ModalStories.Default} sourceState="shown" />
+<Controls of={ModalStories.Default} />

--- a/front/src/ui/organisms/modal/Modal.scss
+++ b/front/src/ui/organisms/modal/Modal.scss
@@ -1,0 +1,56 @@
+@use '../../../utils/sass/mixins/helpers';
+
+.ds-modal {
+  padding: 0;
+  border: none;
+  border: helpers.px-to-rem(1) solid var(--color-black);
+  border-radius: helpers.px-to-rem(10);
+  padding: helpers.px-to-rem(12);
+  background: white;
+  min-width: helpers.px-to-rem(300);
+}
+
+.ds-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: helpers.px-to-rem(12);
+}
+
+.ds-modal__close-button {
+  background: transparent;
+  border: none;
+  font-size: helpers.px-to-rem(20);
+  cursor: pointer;
+  color: var(--color-primary);
+  width: fit-content;
+  padding: helpers.px-to-rem(0);
+  align-self: flex-start;
+  font-weight: 400;
+
+  &:hover {
+    color: var(--color-primary-dark);
+  }
+}
+
+.ds-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: helpers.px-to-rem(8);
+  padding-top: helpers.px-to-rem(12);
+}
+
+.ds-modal__close-action {
+  background: transparent;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: helpers.px-to-rem(14);
+  padding: helpers.px-to-rem(8) helpers.px-to-rem(16);
+  border-radius: helpers.px-to-rem(4);
+
+  &:hover {
+    background: var(--color-primary-light);
+    color: var(--color-primary-dark);
+  }
+}

--- a/front/src/ui/organisms/modal/Modal.scss
+++ b/front/src/ui/organisms/modal/Modal.scss
@@ -1,30 +1,35 @@
 @use '../../../utils/sass/mixins/helpers';
+@use '../../../utils/sass/mixins/responsive';
 
 .ds-modal {
-  min-width: helpers.px-to-rem(300);
+  display: grid;
+  gap: helpers.px-to-rem(12);
   padding: helpers.px-to-rem(12);
-  border: helpers.px-to-rem(1) solid var(--color-black);
-  border-radius: helpers.px-to-rem(10);
-  background: white;
+  width: 100%;
+  margin: auto auto 0;
+  border: helpers.px-to-rem(1) solid var(--color-grey-300);
+  border-radius: helpers.px-to-rem(10) helpers.px-to-rem(10) 0 0;
+  background: var(--color-white);
+
+  @include responsive.media-exceeds-width(tablet) {
+    min-width: helpers.px-to-rem(300);
+    width: fit-content;
+    margin: auto;
+    border-radius: helpers.px-to-rem(10);
+  }
 
   &__header {
     display: flex;
-    padding-bottom: helpers.px-to-rem(12);
     align-items: center;
     justify-content: space-between;
   }
 
   &__footer {
     display: flex;
-    padding-top: helpers.px-to-rem(12);
     justify-content: flex-end;
     gap: helpers.px-to-rem(8);
 
-    .ds-button.ds-modal__button--close {
-      width: fit-content;
-    }
-
-    .ds-button.ds-modal__button--action {
+    .ds-modal__footer-button {
       width: fit-content;
     }
   }

--- a/front/src/ui/organisms/modal/Modal.scss
+++ b/front/src/ui/organisms/modal/Modal.scss
@@ -2,18 +2,21 @@
 @use '../../../utils/sass/mixins/responsive';
 
 .ds-modal {
-  display: grid;
-  gap: helpers.px-to-rem(12);
-  padding: helpers.px-to-rem(12);
   width: 100%;
   margin: auto auto 0;
+  padding: helpers.px-to-rem(12);
   border: helpers.px-to-rem(1) solid var(--color-grey-300);
   border-radius: helpers.px-to-rem(10) helpers.px-to-rem(10) 0 0;
-  background: var(--color-white);
+
+  &[open] {
+    display: flex;
+    flex-direction: column;
+    row-gap: helpers.px-to-rem(12);
+  }
 
   @include responsive.media-exceeds-width(tablet) {
-    min-width: helpers.px-to-rem(300);
     width: fit-content;
+    min-width: helpers.px-to-rem(300);
     margin: auto;
     border-radius: helpers.px-to-rem(10);
   }
@@ -28,9 +31,9 @@
     display: flex;
     justify-content: flex-end;
     gap: helpers.px-to-rem(8);
+  }
 
-    .ds-modal__footer-button {
-      width: fit-content;
-    }
+  &__footer > button {
+    width: fit-content;
   }
 }

--- a/front/src/ui/organisms/modal/Modal.scss
+++ b/front/src/ui/organisms/modal/Modal.scss
@@ -1,56 +1,31 @@
 @use '../../../utils/sass/mixins/helpers';
 
 .ds-modal {
-  padding: 0;
-  border: none;
+  min-width: helpers.px-to-rem(300);
+  padding: helpers.px-to-rem(12);
   border: helpers.px-to-rem(1) solid var(--color-black);
   border-radius: helpers.px-to-rem(10);
-  padding: helpers.px-to-rem(12);
   background: white;
-  min-width: helpers.px-to-rem(300);
-}
 
-.ds-modal__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-bottom: helpers.px-to-rem(12);
-}
-
-.ds-modal__close-button {
-  background: transparent;
-  border: none;
-  font-size: helpers.px-to-rem(20);
-  cursor: pointer;
-  color: var(--color-primary);
-  width: fit-content;
-  padding: helpers.px-to-rem(0);
-  align-self: flex-start;
-  font-weight: 400;
-
-  &:hover {
-    color: var(--color-primary-dark);
+  &__header {
+    display: flex;
+    padding-bottom: helpers.px-to-rem(12);
+    align-items: center;
+    justify-content: space-between;
   }
-}
 
-.ds-modal__footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: helpers.px-to-rem(8);
-  padding-top: helpers.px-to-rem(12);
-}
+  &__footer {
+    display: flex;
+    padding-top: helpers.px-to-rem(12);
+    justify-content: flex-end;
+    gap: helpers.px-to-rem(8);
 
-.ds-modal__close-action {
-  background: transparent;
-  border: none;
-  color: var(--color-primary);
-  cursor: pointer;
-  font-size: helpers.px-to-rem(14);
-  padding: helpers.px-to-rem(8) helpers.px-to-rem(16);
-  border-radius: helpers.px-to-rem(4);
+    .ds-button.ds-modal__close-button {
+      width: fit-content;
+    }
 
-  &:hover {
-    background: var(--color-primary-light);
-    color: var(--color-primary-dark);
+    .ds-button.ds-modal__action-button {
+      width: fit-content;
+    }
   }
 }

--- a/front/src/ui/organisms/modal/Modal.scss
+++ b/front/src/ui/organisms/modal/Modal.scss
@@ -20,11 +20,11 @@
     justify-content: flex-end;
     gap: helpers.px-to-rem(8);
 
-    .ds-button.ds-modal__close-button {
+    .ds-button.ds-modal__button--close {
       width: fit-content;
     }
 
-    .ds-button.ds-modal__action-button {
+    .ds-button.ds-modal__button--action {
       width: fit-content;
     }
   }

--- a/front/src/ui/organisms/modal/Modal.stories.tsx
+++ b/front/src/ui/organisms/modal/Modal.stories.tsx
@@ -21,6 +21,7 @@ const meta = {
     ref: { table: { disable: true } },
   },
   render: (args: ComponentProps<typeof Modal>) => {
+    // oxlint-disable-next-line react-hooks/rules-of-hooks
     const { modalRef, openModal } = useModal();
 
     return (

--- a/front/src/ui/organisms/modal/Modal.stories.tsx
+++ b/front/src/ui/organisms/modal/Modal.stories.tsx
@@ -1,0 +1,40 @@
+import { useModal } from '@Front/ui/utils/hooks/useModal';
+import type { Meta, StoryObj } from 'storybook-react-rsbuild';
+import { Modal } from './Modal';
+
+const meta = {
+  title: 'Organisms/Modal',
+  component: Modal,
+  args: {
+    title: 'Modal title',
+    children: "Modal's content",
+  },
+  argTypes: {
+    title: { control: 'text' },
+    children: { control: 'text' },
+    className: { table: { disable: true } },
+  },
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+
+const ModalStory = () => {
+  const { modalRef, openModal } = useModal();
+
+  return (
+    <>
+      <button type="button" onClick={openModal}>
+        Open Modal
+      </button>
+      <Modal ref={modalRef} title="Modal title">
+        Modal's content
+      </Modal>
+    </>
+  );
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <ModalStory />,
+};

--- a/front/src/ui/organisms/modal/Modal.stories.tsx
+++ b/front/src/ui/organisms/modal/Modal.stories.tsx
@@ -1,4 +1,6 @@
+import { fn } from 'storybook/test';
 import { useModal } from '@Front/ui/utils/hooks/useModal';
+import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from 'storybook-react-rsbuild';
 import { Modal } from './Modal';
 
@@ -8,61 +10,38 @@ const meta = {
   args: {
     title: 'Modal title',
     children: "Modal's content",
-    primaryButtonProps: { children: 'Action' },
-    secondaryButtonProps: { children: 'Close' },
+    primaryButtonProps: { children: 'Action', onClick: fn() },
+    secondaryButtonProps: { children: 'Close', onClick: fn() },
   },
   argTypes: {
     title: { control: 'text' },
     children: { control: 'text' },
-    className: { table: { disable: true } },
     primaryButtonProps: { table: { disable: true } },
     secondaryButtonProps: { table: { disable: true } },
+  },
+  render: (args: ComponentProps<typeof Modal>) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { modalRef, openModal } = useModal();
+
+    return (
+      <>
+        <button type="button" onClick={openModal}>
+          Open Modal
+        </button>
+        <Modal ref={modalRef} {...args} />
+      </>
+    );
   },
 } satisfies Meta<typeof Modal>;
 
 export default meta;
 
-const DefaultModalStory = () => {
-  const { modalRef, openModal } = useModal();
-
-  return (
-    <>
-      <button type="button" onClick={openModal}>
-        Open Modal
-      </button>
-      <Modal
-        ref={modalRef}
-        title="Modal title"
-        primaryButtonProps={{ children: 'Action' }}
-        secondaryButtonProps={{ children: 'Close' }}
-      >
-        Modal's content
-      </Modal>
-    </>
-  );
-};
-
-const WithOnlyOneButtonModalStory = () => {
-  const { modalRef, openModal } = useModal();
-
-  return (
-    <>
-      <button type="button" onClick={openModal}>
-        Open Modal
-      </button>
-      <Modal ref={modalRef} title="Modal title" primaryButtonProps={{ children: 'Action' }}>
-        Modal's content
-      </Modal>
-    </>
-  );
-}; 
-
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: () => <DefaultModalStory />,
-};
+export const Default: Story = {};
 
 export const WithOnlyOneButton: Story = {
-  render: () => <WithOnlyOneButtonModalStory />,
+  args: {
+    secondaryButtonProps: undefined,
+  },
 };

--- a/front/src/ui/organisms/modal/Modal.stories.tsx
+++ b/front/src/ui/organisms/modal/Modal.stories.tsx
@@ -1,7 +1,7 @@
-import { fn } from 'storybook/test';
 import { useModal } from '@Front/ui/utils/hooks/useModal';
 import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from 'storybook-react-rsbuild';
+import { fn } from 'storybook/test';
 import { Modal } from './Modal';
 
 const meta = {
@@ -11,16 +11,16 @@ const meta = {
     title: 'Modal title',
     children: "Modal's content",
     primaryButtonProps: { children: 'Action', onClick: fn() },
-    secondaryButtonProps: { children: 'Close', onClick: fn() },
+    secondaryButtonProps: { children: 'Action 2', onClick: fn(), variant: 'secondary' },
   },
   argTypes: {
     title: { control: 'text' },
     children: { control: 'text' },
     primaryButtonProps: { table: { disable: true } },
     secondaryButtonProps: { table: { disable: true } },
+    ref: { table: { disable: true } },
   },
   render: (args: ComponentProps<typeof Modal>) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { modalRef, openModal } = useModal();
 
     return (

--- a/front/src/ui/organisms/modal/Modal.stories.tsx
+++ b/front/src/ui/organisms/modal/Modal.stories.tsx
@@ -8,17 +8,21 @@ const meta = {
   args: {
     title: 'Modal title',
     children: "Modal's content",
+    primaryButtonProps: { children: 'Action' },
+    secondaryButtonProps: { children: 'Close' },
   },
   argTypes: {
     title: { control: 'text' },
     children: { control: 'text' },
     className: { table: { disable: true } },
+    primaryButtonProps: { table: { disable: true } },
+    secondaryButtonProps: { table: { disable: true } },
   },
 } satisfies Meta<typeof Modal>;
 
 export default meta;
 
-const ModalStory = () => {
+const DefaultModalStory = () => {
   const { modalRef, openModal } = useModal();
 
   return (
@@ -26,15 +30,39 @@ const ModalStory = () => {
       <button type="button" onClick={openModal}>
         Open Modal
       </button>
-      <Modal ref={modalRef} title="Modal title">
+      <Modal
+        ref={modalRef}
+        title="Modal title"
+        primaryButtonProps={{ children: 'Action' }}
+        secondaryButtonProps={{ children: 'Close' }}
+      >
         Modal's content
       </Modal>
     </>
   );
 };
 
+const WithOnlyOneButtonModalStory = () => {
+  const { modalRef, openModal } = useModal();
+
+  return (
+    <>
+      <button type="button" onClick={openModal}>
+        Open Modal
+      </button>
+      <Modal ref={modalRef} title="Modal title" primaryButtonProps={{ children: 'Action' }}>
+        Modal's content
+      </Modal>
+    </>
+  );
+}; 
+
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => <ModalStory />,
+  render: () => <DefaultModalStory />,
+};
+
+export const WithOnlyOneButton: Story = {
+  render: () => <WithOnlyOneButtonModalStory />,
 };

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -4,7 +4,7 @@ import { Button } from '@Front/ui/molecules/Button/Button';
 import { ClickIcon } from '@Front/ui/molecules/ClickIcon/ClickIcon';
 import { getClassName } from '@Front/utils/getClassName';
 import Close from '@material-symbols/svg-400/rounded/close.svg?react';
-import { type RefObject, useId, type ComponentProps, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+import { useId, type ComponentProps, type ComponentPropsWithoutRef, type ReactNode, type RefObject } from 'react';
 
 import { useModal } from '@Front/ui/utils/hooks/useModal';
 import './Modal.scss';
@@ -14,8 +14,8 @@ type ButtonProps = ComponentProps<typeof Button>;
 type ModalProps = {
   title: string;
   children: ReactNode;
-  primaryButtonProps: Omit<ButtonProps, 'className'>;
-  secondaryButtonProps?: Omit<ButtonProps, 'className'>;
+  primaryButtonProps: ButtonProps;
+  secondaryButtonProps?: ButtonProps;
   ref?: RefObject<HTMLDialogElement | null>;
 } & Omit<ComponentPropsWithoutRef<'dialog'>, 'children' | 'title'>;
 
@@ -38,7 +38,7 @@ export const Modal = ({
 
   return (
     <dialog aria-labelledby={titleId} className={parentClassName} ref={modalRef} {...props} closedby="any">
-      <div className="ds-modal__header">
+      <header className="ds-modal__header">
         <Heading level={1} id={titleId}>
           {title}
         </Heading>
@@ -49,20 +49,14 @@ export const Modal = ({
           icon={Close}
           type="button"
         />
-      </div>
+      </header>
+      
+      <main>{children}</main>
 
-      {children}
-
-      <div className="ds-modal__footer">
-        {secondaryButtonProps && (
-          <Button
-            type="button"
-            className="ds-modal__footer-button"
-            {...secondaryButtonProps}
-          />
-        )}
-        <Button type="button" className="ds-modal__footer-button" {...primaryButtonProps} />
-      </div>
+      <footer className="ds-modal__footer">
+        {secondaryButtonProps && <Button type="button" {...secondaryButtonProps} />}
+        <Button type="button" {...primaryButtonProps} />
+      </footer>
     </dialog>
   );
 };

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -28,7 +28,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
     };
 
     return (
-      <dialog aria-labelledby={titleId} className={parentClassName} ref={ref} {...props}>
+      <dialog aria-labelledby={titleId} className={parentClassName} ref={ref} {...props} closedby="any">
         <div className="ds-modal__header">
           <Heading level={1} id={titleId}>
             {title}

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -1,56 +1,71 @@
 // oxlint-disable react/jsx-props-no-spreading
 import { Heading } from '@Front/ui/atoms/Heading/Heading';
 import { Button } from '@Front/ui/molecules/Button/Button';
+import { ClickIcon } from '@Front/ui/molecules/ClickIcon/ClickIcon';
 import { getClassName } from '@Front/utils/getClassName';
-import { forwardRef, useId, type DialogHTMLAttributes, type ReactNode } from 'react';
+import Close from '@material-symbols/svg-400/rounded/close.svg?react';
+import { type RefObject, useId, type ComponentProps, type ComponentPropsWithoutRef, type ReactNode } from 'react';
 
+import { useModal } from '@Front/ui/utils/hooks/useModal';
 import './Modal.scss';
+
+type ButtonProps = ComponentProps<typeof Button>;
 
 type ModalProps = {
   title: string;
   children: ReactNode;
   className?: string;
-  action?: () => void;
-} & DialogHTMLAttributes<HTMLDialogElement>;
+  primaryButtonProps: Omit<ButtonProps, 'className'>;
+  secondaryButtonProps?: Omit<ButtonProps, 'className'>;
+  ref?: RefObject<HTMLDialogElement | null>;
+} & ComponentPropsWithoutRef<'dialog'>;
 
-export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
-  ({ title, className, children, action, ...props }, ref) => {
-    const titleId = useId();
-    const parentClassName = getClassName({
-      defaultClassName: 'ds-modal',
-      className,
-    });
+export const Modal = ({
+  title,
+  ref,
+  className,
+  children,
+  primaryButtonProps,
+  secondaryButtonProps,
+  ...props
+}: ModalProps) => {
+  const { closeModal, modalRef } = useModal(ref);
 
-    const closeModal = () => {
-      if (ref && 'current' in ref && ref.current) {
-        ref.current.close();
-      }
-    };
+  const titleId = useId();
+  const parentClassName = getClassName({
+    defaultClassName: 'ds-modal',
+    className,
+  });
 
-    return (
-      <dialog aria-labelledby={titleId} className={parentClassName} ref={ref} {...props} closedby="any">
-        <div className="ds-modal__header">
-          <Heading level={1} id={titleId}>
-            {title}
-          </Heading>
-          <Button aria-label="Fermer la fenêtre" onClick={closeModal} className="ds-modal__close-button">
-            x
-          </Button>
-        </div>
+  return (
+    <dialog aria-labelledby={titleId} className={parentClassName} ref={modalRef} {...props} closedby="any">
+      <div className="ds-modal__header">
+        <Heading level={1} id={titleId}>
+          {title}
+        </Heading>
+        <ClickIcon
+          aria-label="Fermer la fenêtre"
+          onClick={closeModal}
+          className="ds-modal__close-button"
+          icon={Close}
+        />
+      </div>
 
-        {children}
+      {children}
 
-        <div className="ds-modal__footer">
-          <Button onClick={closeModal} className="ds-modal__close-button">
-            Fermer
-          </Button>
-          <Button onClick={action} className="ds-modal__close-action">
-            Action
-          </Button>
-        </div>
-      </dialog>
-    );
-  },
-);
+      <div className="ds-modal__footer">
+        {secondaryButtonProps && (
+          <Button
+            className="ds-modal__close-button"
+            {...secondaryButtonProps}
+            variant="secondary"
+            onClick={closeModal}
+          />
+        )}
+        <Button className="ds-modal__action-button" {...primaryButtonProps} />
+      </div>
+    </dialog>
+  );
+};
 
 Modal.displayName = 'Modal';

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -14,11 +14,10 @@ type ButtonProps = ComponentProps<typeof Button>;
 type ModalProps = {
   title: string;
   children: ReactNode;
-  className?: string;
   primaryButtonProps: Omit<ButtonProps, 'className'>;
   secondaryButtonProps?: Omit<ButtonProps, 'className'>;
   ref?: RefObject<HTMLDialogElement | null>;
-} & ComponentPropsWithoutRef<'dialog'>;
+} & Omit<ComponentPropsWithoutRef<'dialog'>, 'children' | 'title'>;
 
 export const Modal = ({
   title,
@@ -55,22 +54,14 @@ export const Modal = ({
       {children}
 
       <div className="ds-modal__footer">
-        {secondaryButtonProps && (() => {
-          const { onClick, ...secondaryButtonRestProps } = secondaryButtonProps;
-
-          return (
-            <Button
-              className="ds-modal__close-button"
-              {...secondaryButtonRestProps}
-              variant="secondary"
-              onClick={(event) => {
-                onClick?.(event);
-                closeModal();
-              }}
-            />
-          );
-        })()}
-        <Button className="ds-modal__button--action" {...primaryButtonProps} />
+        {secondaryButtonProps && (
+          <Button
+            type="button"
+            className="ds-modal__footer-button"
+            {...secondaryButtonProps}
+          />
+        )}
+        <Button type="button" className="ds-modal__footer-button" {...primaryButtonProps} />
       </div>
     </dialog>
   );

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -48,6 +48,7 @@ export const Modal = ({
           onClick={closeModal}
           className="ds-modal__button--close"
           icon={Close}
+          type="button"
         />
       </div>
 

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -1,23 +1,56 @@
 // oxlint-disable react/jsx-props-no-spreading
+import { Heading } from '@Front/ui/atoms/Heading/Heading';
+import { Button } from '@Front/ui/molecules/Button/Button';
 import { getClassName } from '@Front/utils/getClassName';
-import type { HTMLAttributes, ReactNode } from 'react';
+import { forwardRef, useId, type DialogHTMLAttributes, type ReactNode } from 'react';
+
+import './Modal.scss';
 
 type ModalProps = {
   title: string;
   children: ReactNode;
   className?: string;
-} & HTMLAttributes<HTMLDivElement>;
+  action?: () => void;
+} & DialogHTMLAttributes<HTMLDialogElement>;
 
-export const Modal = ({ title, className, children, ...props }: ModalProps) => {
-  const parentClassName = getClassName({
-    defaultClassName: 'ds-modal',
-    className,
-  });
+export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
+  ({ title, className, children, action, ...props }, ref) => {
+    const titleId = useId();
+    const parentClassName = getClassName({
+      defaultClassName: 'ds-modal',
+      className,
+    });
 
-  return (
-    <div className={parentClassName} {...props}>
-      {title}
-      {children}
-    </div>
-  );
-};
+    const closeModal = () => {
+      if (ref && 'current' in ref && ref.current) {
+        ref.current.close();
+      }
+    };
+
+    return (
+      <dialog aria-labelledby={titleId} className={parentClassName} ref={ref} {...props}>
+        <div className="ds-modal__header">
+          <Heading level={1} id={titleId}>
+            {title}
+          </Heading>
+          <Button aria-label="Fermer la fenêtre" onClick={closeModal} className="ds-modal__close-button">
+            x
+          </Button>
+        </div>
+
+        {children}
+
+        <div className="ds-modal__footer">
+          <Button onClick={closeModal} className="ds-modal__close-button">
+            Fermer
+          </Button>
+          <Button onClick={action} className="ds-modal__close-action">
+            Action
+          </Button>
+        </div>
+      </dialog>
+    );
+  },
+);
+
+Modal.displayName = 'Modal';

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -55,14 +55,21 @@ export const Modal = ({
       {children}
 
       <div className="ds-modal__footer">
-        {secondaryButtonProps && (
-          <Button
-            className="ds-modal__button--close"
-            {...secondaryButtonProps}
-            variant="secondary"
-            onClick={closeModal}
-          />
-        )}
+        {secondaryButtonProps && (() => {
+          const { onClick, ...secondaryButtonRestProps } = secondaryButtonProps;
+
+          return (
+            <Button
+              className="ds-modal__close-button"
+              {...secondaryButtonRestProps}
+              variant="secondary"
+              onClick={(event) => {
+                onClick?.(event);
+                closeModal();
+              }}
+            />
+          );
+        })()}
         <Button className="ds-modal__button--action" {...primaryButtonProps} />
       </div>
     </dialog>

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -46,7 +46,7 @@ export const Modal = ({
         <ClickIcon
           aria-label="Fermer la fenêtre"
           onClick={closeModal}
-          className="ds-modal__close-button"
+          className="ds-modal__button--close"
           icon={Close}
         />
       </div>
@@ -56,13 +56,13 @@ export const Modal = ({
       <div className="ds-modal__footer">
         {secondaryButtonProps && (
           <Button
-            className="ds-modal__close-button"
+            className="ds-modal__button--close"
             {...secondaryButtonProps}
             variant="secondary"
             onClick={closeModal}
           />
         )}
-        <Button className="ds-modal__action-button" {...primaryButtonProps} />
+        <Button className="ds-modal__button--action" {...primaryButtonProps} />
       </div>
     </dialog>
   );

--- a/front/src/ui/organisms/modal/Modal.tsx
+++ b/front/src/ui/organisms/modal/Modal.tsx
@@ -1,0 +1,23 @@
+// oxlint-disable react/jsx-props-no-spreading
+import { getClassName } from '@Front/utils/getClassName';
+import type { HTMLAttributes, ReactNode } from 'react';
+
+type ModalProps = {
+  title: string;
+  children: ReactNode;
+  className?: string;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const Modal = ({ title, className, children, ...props }: ModalProps) => {
+  const parentClassName = getClassName({
+    defaultClassName: 'ds-modal',
+    className,
+  });
+
+  return (
+    <div className={parentClassName} {...props}>
+      {title}
+      {children}
+    </div>
+  );
+};

--- a/front/src/ui/organisms/modal/__tests__/Modal.test.tsx
+++ b/front/src/ui/organisms/modal/__tests__/Modal.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
 
 import { Modal } from '../Modal';
 

--- a/front/src/ui/organisms/modal/__tests__/Modal.test.tsx
+++ b/front/src/ui/organisms/modal/__tests__/Modal.test.tsx
@@ -37,13 +37,13 @@ describe('Modal', () => {
   });
 
   it('should link dialog label to the title heading and set closedby attribute', () => {
-    const { container } = render(
+    render(
       <Modal open title="Modal title" primaryButtonProps={{ children: 'Action' }}>
         Modal content
       </Modal>,
     );
 
-    const dialog = container.querySelector('dialog');
+    const dialog = screen.getByRole('dialog', { hidden: true });
     const heading = screen.getByRole('heading', { name: 'Modal title' });
 
     expect(dialog).toBeInTheDocument();
@@ -51,13 +51,13 @@ describe('Modal', () => {
     expect(dialog).toHaveAttribute('closedby', 'any');
   });
 
-  it('should force secondary button variant to secondary', () => {
+  it('should apply the variant passed via secondaryButtonProps', () => {
     render(
       <Modal
         open
         title="Modal title"
         primaryButtonProps={{ children: 'Action' }}
-        secondaryButtonProps={{ children: 'Close', variant: 'primary' }}
+        secondaryButtonProps={{ children: 'Close', variant: 'secondary' }}
       >
         Modal content
       </Modal>,
@@ -68,14 +68,24 @@ describe('Modal', () => {
 
   it('should forward native dialog attributes', () => {
     const onClose = vi.fn();
-    const { container } = render(
+    render(
       <Modal title="Modal title" primaryButtonProps={{ children: 'Action' }} open onClose={onClose}>
         Modal content
       </Modal>,
     );
 
-    const dialog = container.querySelector('dialog');
+    expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute('open');
+  });
 
-    expect(dialog).toHaveAttribute('open');
+  it('should apply a custom className alongside the default class', () => {
+    render(
+      <Modal open title="Modal title" primaryButtonProps={{ children: 'Action' }} className="custom-modal">
+        Modal content
+      </Modal>,
+    );
+
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(dialog).toHaveClass('ds-modal');
+    expect(dialog).toHaveClass('custom-modal');
   });
 });

--- a/front/src/ui/organisms/modal/__tests__/Modal.test.tsx
+++ b/front/src/ui/organisms/modal/__tests__/Modal.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Modal } from '../Modal';
+
+describe('Modal', () => {
+  it('should render title, content, and footer actions', () => {
+    render(
+      <Modal
+        open
+        title="Modal title"
+        primaryButtonProps={{ children: 'Action' }}
+        secondaryButtonProps={{ children: 'Close' }}
+      >
+        Modal content
+      </Modal>,
+    );
+
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(dialog).toBeInTheDocument();
+    within(dialog).getByRole('heading', { name: 'Modal title' });
+    expect(within(dialog).getByText('Modal content')).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Action' })).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  it('should not render secondary action when secondaryButtonProps is not provided', () => {
+    render(
+      <Modal open title="Modal title" primaryButtonProps={{ children: 'Action' }}>
+        Modal content
+      </Modal>,
+    );
+
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(within(dialog).getByRole('button', { name: 'Action' })).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+  });
+
+  it('should link dialog label to the title heading and set closedby attribute', () => {
+    const { container } = render(
+      <Modal open title="Modal title" primaryButtonProps={{ children: 'Action' }}>
+        Modal content
+      </Modal>,
+    );
+
+    const dialog = container.querySelector('dialog');
+    const heading = screen.getByRole('heading', { name: 'Modal title' });
+
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-labelledby', heading.id);
+    expect(dialog).toHaveAttribute('closedby', 'any');
+  });
+
+  it('should force secondary button variant to secondary', () => {
+    render(
+      <Modal
+        open
+        title="Modal title"
+        primaryButtonProps={{ children: 'Action' }}
+        secondaryButtonProps={{ children: 'Close', variant: 'primary' }}
+      >
+        Modal content
+      </Modal>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveClass('ds-button--secondary');
+  });
+
+  it('should forward native dialog attributes', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <Modal title="Modal title" primaryButtonProps={{ children: 'Action' }} open onClose={onClose}>
+        Modal content
+      </Modal>,
+    );
+
+    const dialog = container.querySelector('dialog');
+
+    expect(dialog).toHaveAttribute('open');
+  });
+});


### PR DESCRIPTION
**Title:** Create Modal organism component

**Type of Pull Request:**

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #385

**Context:**
Implements a reusable Modal dialog component that serves as a confirmation/focused interaction component. The Modal is built on the native HTML `<dialog>` element and provides accessible, keyboard-operable interactions with a required primary action button and optional secondary action button.

**Proposed Changes:**
- **Modal.tsx**: Core component featuring a native dialog with accessible title linking via `aria-labelledby`, header with close icon button, flexible body content, and footer with primary/secondary action buttons
- **Modal.scss**: Styling for modal structure including header (title + close button), body, and footer layouts with appropriate spacing
- **Modal.stories.tsx**: Storybook stories demonstrating default and single-button modal configurations
- **Modal.mdx**: Comprehensive documentation including usage examples, prop descriptions, accessibility notes, and playground
- **Modal.test.tsx**: Unit tests covering rendering, optional secondary button, aria labeling, closedby attribute, and button variant handling
- **Button component updates**: Enhanced Button prop forwarding to support full prop coverage (accessibility attributes, etc.)
- **Card component updates**: Import reorganization and linting configuration adjustments

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
- Component supports native dialog attributes and forwards them properly
- Secondary button variant is always forced to "secondary" by the component for visual consistency
- Uses `useModal` hook for controlled dialog ref management
- Depends on #235 (Heading component)