### PR TITLE
chore: fix Renovate auto-merge configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":timezone(Europe/Paris)", ":enableVulnerabilityAlertsWithLabel(security)"],
+  "extends": ["config:recommended", "mergeConfidence:badge-only", ":timezone(Europe/Paris)", ":enableVulnerabilityAlertsWithLabel(security)"],
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "minimumReleaseAge": "5 days",


### PR DESCRIPTION
**Title:** Fix Renovate auto-merge configuration

**Type of Pull Request:**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #882

**Context:**
The auto-merge feature in Renovate was not working despite having correct configuration in `renovate.json`. This was likely due to required reviewers blocking automatic merges. By adding `mergeConfidence:badge-only` to the configuration, we enable Renovate to proceed with auto-merge on patch updates when merge confidence is sufficient.

**Proposed Changes:**
- Added `"mergeConfidence:badge-only"` to the Renovate `extends` array in `.github/renovate.json`
- This configuration allows Renovate to automatically merge patch updates without waiting for additional confidence checks, while still respecting required reviewer policies where applicable

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
This is a configuration fix for dependency management automation. The change enables faster patch updates while maintaining security standards through Renovate's merge confidence filtering.