### PR TITLE
chore: fix Renovate configuration error and enable automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "mergeConfidence:badge-only", ":timezone(Europe/Paris)", ":enableVulnerabilityAlertsWithLabel(security)"],
+  "extends": ["config:recommended", ":timezone(Europe/Paris)", ":enableVulnerabilityAlertsWithLabel(security)"],
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "minimumReleaseAge": "5 days",
+  "statusCheckNames": {
+    "mergeConfidence": null
+  },
   "npm": {
     "rangeStrategy": "bump"
   },


### PR DESCRIPTION
**Title:** Fix Renovate configuration error and enable automerge

**Type of Pull Request:**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #888

**Context:**
Renovate configuration had an invalid preset (`mergeConfidence:badge-only`) that caused Renovate to fail with a config validation error and stop creating/merging PRs. The issue #888 was automatically created by Renovate to alert about this configuration problem.

**Proposed Changes:**
- Removed the invalid `mergeConfidence:badge-only` preset that was not recognized by Renovate
- Added `statusCheckNames.mergeConfidence: null` to disable the GitHub status check `renovate/merge-confidence` (which was previously blocking automerge even when configured)
- This allows automerge to function correctly based on the `minimumConfidence` rule while keeping the merge confidence badge visible in PRs for informational purposes

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
Config validated successfully with `renovate-config-validator --strict`. Automerge should now work for patch updates with `minimumConfidence: "neutral"` without being blocked by the merge confidence status check.