### PR TITLE
chore: use direct branch pushes for Renovate patch automerges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,12 +44,14 @@
       "matchUpdateTypes": ["patch"],
       "minimumConfidence": "neutral",
       "automerge": true,
+      "automergeType": "branch",
       "minimumReleaseAge": "7 days"
     },
     {
       "matchUpdateTypes": ["patch"],
       "minimumConfidence": "high",
       "automerge": true,
+      "automergeType": "branch",
       "minimumReleaseAge": "5 days"
     }
   ]


### PR DESCRIPTION
**Title:** Use direct branch pushes for Renovate patch automerges

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
Renovate automerge for patch updates was blocked by CODEOWNER review requirements despite bypass list configuration. Using `automergeType: "branch"` allows Renovate to push directly to `main` for patch updates, bypassing GitHub's native PR merge flow and its associated review restrictions, while keeping the default PR-based merge for major/minor updates.

**Proposed Changes:**
- Added `"automergeType": "branch"` to both patch automerge rules in `.github/renovate.json`
- Only applies to patch updates with `minimumConfidence: "neutral"` (7 days) or `"high"` (5 days)
- Major and minor updates continue to create PRs (default behavior)
- Removes need for separate GitHub Actions workflow or PAT secret

**Checklist:**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
Trade-off: Patch updates will no longer appear as PRs in the repository history—they'll be direct commits to `main`. This simplifies the workflow and reduces visibility for automated patch updates, which is acceptable given their low-risk nature (neutral/high merge confidence, 5-7 day minimum age).