### PR TITLE
chore: fix conflicting Renovate patch rules to enable automerge for neutral confidence updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,8 +49,7 @@
     },
     {
       "matchUpdateTypes": ["patch"],
-      "minimumConfidence": "high",
-      "automerge": true,
+      "matchConfidence": ["high", "very high"],
       "automergeType": "branch",
       "minimumReleaseAge": "5 days"
     }


### PR DESCRIPTION
**Title:** Fix conflicting Renovate patch rules to enable automerge for neutral confidence updates

**Type of Pull Request:**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
Renovate patch automerge was silently failing for `neutral` confidence updates (e.g., react). The two patch rules were conflicting: rule 2's `minimumConfidence: "high"` was overriding rule 1's `"neutral"`, causing Renovate to skip any patch with lower confidence without creating a PR or pushing anything.

**Proposed Changes:**
- Rule 1: All patch updates with `minimumConfidence: "neutral"` and `automerge: true` (7-day minimum age), with `automergeType: "branch"` for direct pushes
- Rule 2: Override only for `high`/`very high` confidence patches via `matchConfidence` (avoiding `minimumConfidence` override), reducing minimum age to 5 days while keeping `automergeType: "branch"`
- No conflicts: rule 2 filters by confidence level rather than overriding the threshold

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
Trade-off: Patch updates will appear as direct commits to `main` rather than PRs due to `automergeType: "branch"`. This reduces visibility for automated patches but is acceptable for low-risk updates (neutral/high merge confidence, 5-7 day minimum age). Requires Rulesets bypass to allow direct pushes from Renovate.