### PR TITLE
chore: remove matchConfidence rule to resolve Renovate authentication blocker

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,12 +46,6 @@
       "automerge": true,
       "automergeType": "branch",
       "minimumReleaseAge": "7 days"
-    },
-    {
-      "matchUpdateTypes": ["patch"],
-      "matchConfidence": ["high", "very high"],
-      "automergeType": "branch",
-      "minimumReleaseAge": "5 days"
     }
   ]
 }


### PR DESCRIPTION
**Title:** Remove matchConfidence rule to resolve Renovate authentication blocker

**Type of Pull Request:**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #899

**Context:**
Renovate paused all PRs due to a missing credentials error: the `matchConfidence` matcher in `packageRules` requires Mend authentication, which is not available at the repository config level. This prevents Renovate from operating until the configuration is fixed.

**Proposed Changes:**
- Removed the second patch rule that used `matchConfidence: ["high", "very high"]` with 5-day minimum release age
- Kept the first patch rule: all patches with `minimumConfidence: "neutral"` and `automergeType: "branch"` for 7-day minimum age
- Result: All patch updates with neutral or higher merge confidence will automerge directly to `main` after 7 days

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
Trade-off: High-confidence patches no longer benefit from reduced 5-day wait time; all patches now wait 7 days. This is acceptable given the critical need to unblock Renovate. Patch updates will be direct commits to `main` via `automergeType: "branch"`, reducing PR visibility but acceptable for low-risk updates.