### PR TITLE
chore: enable CI workflows to run on Renovate branches for direct automerge

### DIFF
--- a/.github/workflows/back-build.yaml
+++ b/.github/workflows/back-build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "renovate/**"
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - main
+      - "renovate/**"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-
   workflow_dispatch:
   merge_group:
     branches: ["main"]

--- a/.github/workflows/front-build.yaml
+++ b/.github/workflows/front-build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "renovate/**"
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -1,6 +1,9 @@
 name: PR Title Check
 
 on:
+  push:
+    branches:
+      - "renovate/**"
   pull_request:
     types: [opened, edited, synchronize, reopened]
   merge_group:
@@ -12,12 +15,8 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Skip validation for merge group
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping PR title validation for merge group"
-
       - name: Validate PR title follows Conventional Commits
-        if: github.event_name != 'merge_group'
+        if: github.event_name == 'pull_request'
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Title:** Enable CI workflows to run on Renovate branches for direct automerge

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
With `automergeType: "branch"` in Renovate configuration, patch updates are pushed directly to `main` without creating PRs. However, the required status checks (Back Build, Front Build, Docker Build, PR Title Check) were only configured to run on `pull_request` events, not on direct pushes to `renovate/**` branches. This caused Renovate to wait indefinitely for checks that never ran, blocking the automerge.

**Proposed Changes:**
- Added `push: branches: ["renovate/**"]` trigger to `back-build.yaml`, `front-build.yaml`, and `docker-build.yml` workflows
- Updated `pr-title-check.yaml` to run on `push` events for `renovate/**` branches, but only validate on `pull_request` events (skips validation on direct pushes via simplified conditional)
- Removed superfluous "skip merge group" logic from `pr-title-check.yaml`
- Cleaned up unused `paths` declaration in `docker-build.yml`

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
These changes enable Renovate's direct branch automerge to work correctly by ensuring all required CI checks run on `renovate/**` branches before Renovate pushes to `main`. The `pr-title-check` workflow now intelligently skips title validation for Renovate branch pushes (not applicable without a PR), while still validating human PRs.