### PR TITLE
fix: rsbuild 2.0 host binding for traefik access

### DIFF
--- a/front/rsbuild.config.ts
+++ b/front/rsbuild.config.ts
@@ -62,6 +62,7 @@ export default defineConfig(({ env }) => {
       lazyCompilation: false,
     },
     server: {
+      host: process.env.HOST ?? '0.0.0.0',
       port: Number.parseInt(process.env.PORT ?? '3000', 10),
       open: (process.env.BROWSER ?? 'false') === 'true',
     },


### PR DESCRIPTION
**Title:** Fix Rsbuild 2.0 host binding for Traefik access

**Type of Pull Request:**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
N/A

**Context:**
Rsbuild 2.0 introduced a breaking change where the default server host changed from `0.0.0.0` to `localhost` (PR #6940). This prevents the dev server from being accessible via the Docker network, breaking access from Traefik in dev container environments. The frontend becomes unreachable at `https://localhost` when routed through Traefik.

**Proposed Changes:**
- Added explicit `host` configuration to the Rsbuild server settings
- Set default host to `0.0.0.0` to restore accessibility across network interfaces
- Made the host configurable via the `HOST` environment variable to support different deployment scenarios

**Checklist:**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
This fix allows the dev server to be accessed from Traefik running in the same Docker network. Users can override the host binding via the `HOST` environment variable if needed for their specific environment.