### PR TITLE
feat: textfield component

### DIFF
--- a/front/src/components/TextField/TextField.tsx
+++ b/front/src/components/TextField/TextField.tsx
@@ -1,22 +1,17 @@
 import { TextInput } from '@Front/ui/molecules/Inputs/TextInput/TextInput';
-import { RegisterOptions, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
-type TextInputProps = Omit<React.ComponentProps<typeof TextInput>, 'value' | 'onChange' | 'onBlur' | 'error'> & {
-  name: string;
-  rules?: RegisterOptions;
-};
+type TextInputProps = Omit<React.ComponentProps<typeof TextInput>, 'error'>;
 
-export const TextField = ({ name, rules, id, ...props }: TextInputProps) => {
+export const TextField = (props : TextInputProps) => {
   const { register, formState } = useFormContext();
   const { errors } = formState;
 
   return (
     <TextInput
       {...props}
-      {...(register(name, { ...rules }) as Partial<TextInputProps>)}
-      id={id ?? name}
-      name={name}
-      error={errors[name]?.message as string}
+      {...(register(props.name))}
+      error={errors[props.name]?.message as string}
     />
   );
 };

--- a/front/src/components/TextField/TextField.tsx
+++ b/front/src/components/TextField/TextField.tsx
@@ -1,32 +1,22 @@
 import { TextInput } from '@Front/ui/molecules/Inputs/TextInput/TextInput';
-import { useController, type UseControllerProps, type FieldValues } from 'react-hook-form';
+import { RegisterOptions, useFormContext } from 'react-hook-form';
 
-type TextInputProps<Type extends FieldValues> = UseControllerProps<Type> & 
-  Omit<React.ComponentProps<typeof TextInput>, 'value' | 'onChange' | 'onBlur' | 'error'>;
+type TextInputProps = Omit<React.ComponentProps<typeof TextInput>, 'value' | 'onChange' | 'onBlur' | 'error'> & {
+  name: string;
+  rules?: RegisterOptions;
+};
 
-export const TextField = <Type extends FieldValues>({
-  name,
-  control,
-  rules,
-  defaultValue,
-  ...props
-}: TextInputProps<Type>) => {
-  const {
-    field,
-    fieldState: { error },
-  } = useController({
-    name,
-    control,
-    rules,
-    defaultValue,
-  });
+export const TextField = ({ name, rules, id, ...props }: TextInputProps) => {
+  const { register, formState } = useFormContext();
+  const { errors } = formState;
 
   return (
     <TextInput
       {...props}
-      {...field}
-      error={error?.message}
-      required={props.required}
+      {...(register(name, { ...rules }) as Partial<TextInputProps>)}
+      id={id ?? name}
+      name={name}
+      error={errors[name]?.message as string}
     />
   );
 };

--- a/front/src/components/TextField/TextField.tsx
+++ b/front/src/components/TextField/TextField.tsx
@@ -1,7 +1,8 @@
 import { TextInput } from '@Front/ui/molecules/Inputs/TextInput/TextInput';
+import { type ComponentProps } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-type TextInputProps = Omit<React.ComponentProps<typeof TextInput>, 'error'>;
+type TextInputProps = Omit<ComponentProps<typeof TextInput>, 'error'>;
 
 export const TextField = (props : TextInputProps) => {
   const { register, formState } = useFormContext();

--- a/front/src/components/TextField/TextField.tsx
+++ b/front/src/components/TextField/TextField.tsx
@@ -1,0 +1,32 @@
+import { TextInput } from '@Front/ui/molecules/Inputs/TextInput/TextInput';
+import { useController, type UseControllerProps, type FieldValues } from 'react-hook-form';
+
+type TextInputProps<Type extends FieldValues> = UseControllerProps<Type> & 
+  Omit<React.ComponentProps<typeof TextInput>, 'value' | 'onChange' | 'onBlur' | 'error'>;
+
+export const TextField = <Type extends FieldValues>({
+  name,
+  control,
+  rules,
+  defaultValue,
+  ...props
+}: TextInputProps<Type>) => {
+  const {
+    field,
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules,
+    defaultValue,
+  });
+
+  return (
+    <TextInput
+      {...props}
+      {...field}
+      error={error?.message}
+      required={props.required}
+    />
+  );
+};

--- a/front/src/components/TextField/__tests__/TextField.test.tsx
+++ b/front/src/components/TextField/__tests__/TextField.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+import { TextField } from '../TextField';
+import { type ReactNode } from 'react';
+
+const FormWrapper = ({
+  children,
+  defaultValues = {},
+}: {
+  children: ReactNode;
+  defaultValues?: Record<string, unknown>;
+}) => {
+  const methods = useForm({ defaultValues });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('TextField', () => {
+  it('renders without crashing', () => {
+    render(
+      <FormWrapper>
+        <TextField name="username" label="Username" />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+  });
+
+  it('renders with the correct name attribute', () => {
+    render(
+      <FormWrapper>
+        <TextField name="email" label="Email" />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByLabelText('Email')).toHaveAttribute('name', 'email');
+  });
+
+  it('passes extra props down to TextInput', () => {
+    render(
+      <FormWrapper>
+        <TextField name="search" label="Search" placeholder="Search…" />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByPlaceholderText('Search…')).toBeInTheDocument();
+  });
+
+  it('displays the error message from form state when validation fails', async () => {
+    const WrapperWithError = () => {
+      const methods = useForm({ defaultValues: { username: '' } });
+
+      const { setError } = methods;
+
+      return (
+        <FormProvider {...methods}>
+          <TextField name="username" label="Username" />
+          <button onClick={() => setError('username', { message: 'This field is required' })}>Trigger error</button>
+        </FormProvider>
+      );
+    };
+
+    render(<WrapperWithError />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Trigger error' }));
+
+    expect(await screen.findByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('updates the input value on user typing', async () => {
+    render(
+      <FormWrapper>
+        <TextField name="firstName" label="First Name" />
+      </FormWrapper>,
+    );
+
+    const input = screen.getByLabelText('First Name');
+    await userEvent.type(input, 'Test');
+
+    expect(input).toHaveValue('Test');
+  });
+});

--- a/front/src/components/TextField/__tests__/TextField.test.tsx
+++ b/front/src/components/TextField/__tests__/TextField.test.tsx
@@ -19,31 +19,13 @@ describe('TextField', () => {
   it('renders without crashing', () => {
     render(
       <FormWrapper>
-        <TextField name="username" label="Username" />
+        <TextField name="email" label="Email" placeholder="Enter your email" />
       </FormWrapper>,
     );
 
-    expect(screen.getByLabelText('Username')).toBeInTheDocument();
-  });
-
-  it('renders with the correct name attribute', () => {
-    render(
-      <FormWrapper>
-        <TextField name="email" label="Email" />
-      </FormWrapper>,
-    );
-
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
     expect(screen.getByLabelText('Email')).toHaveAttribute('name', 'email');
-  });
-
-  it('passes extra props down to TextInput', () => {
-    render(
-      <FormWrapper>
-        <TextField name="search" label="Search" placeholder="Search…" />
-      </FormWrapper>,
-    );
-
-    expect(screen.getByPlaceholderText('Search…')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter your email')).toBeInTheDocument();
   });
 
   it('displays the error message from form state when validation fails', async () => {


### PR DESCRIPTION
**Title:** Add TextField component with react-hook-form integration

**Type of Pull Request:**

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #240

**Context:**
This PR implements the TextField component as part of the MVP milestone. The component abstracts the TextInput molecule from the toolkit and integrates it with react-hook-form, providing automatic form registration and error handling. This component will be used across multiple pages including sign-up, login, and event creation forms.

**Proposed Changes:**
- Created new `TextField` component in `front/src/components/TextField/TextField.tsx`
- Component wraps `TextInput` molecule and integrates with `react-hook-form` via `useFormContext`
- Automatically registers form fields and displays validation errors
- Provides a clean API that accepts all TextInput props while managing form state internally

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
This component is a blocker for 6 related issues including the form column creation and event creation pages. The dependency on issue #237 (TextInput component) has been resolved.