### PR TITLE
chore: add explicit workflow-level permissions to build workflows

### DIFF
--- a/.github/workflows/back-build.yaml
+++ b/.github/workflows/back-build.yaml
@@ -11,6 +11,9 @@ on:
   merge_group:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   BACK_FOLDER: ./back
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,9 @@ on:
   merge_group:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     name: Detect Docker Changes

--- a/.github/workflows/front-build.yaml
+++ b/.github/workflows/front-build.yaml
@@ -11,6 +11,9 @@ on:
   merge_group:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   FRONT_FOLDER: ./front
 


### PR DESCRIPTION
**Type of Pull Request:**

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Addresses CodeQL security scanning issue: https://github.com/ZideStudio/SlotFinder/security/code-scanning/14

**Context:**
GitHub Actions security best practices recommend setting explicit workflow-level permissions to enforce least-privilege access. This reduces security risk by ensuring jobs only have the minimum permissions required. The CodeQL scanning alert flagged missing explicit `permissions` blocks in the build workflows.

**Proposed Changes:**
- Added explicit `permissions: contents: read` block to `.github/workflows/back-build.yaml`
- Added explicit `permissions: contents: read` block to `.github/workflows/docker-build.yml`
- Added explicit `permissions: contents: read` block to `.github/workflows/front-build.yaml`

Permissions blocks are placed after the `on:` trigger and before environment variables (`env:`) to follow GitHub Actions best practices. This ensures all jobs in these workflows inherit the least-privilege defaults unless explicitly overridden at the job level.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
This is a minimal, non-breaking change that preserves existing workflow behavior while addressing the security scanning alert. The `contents: read` permission is appropriate for these build workflows, which primarily need to read repository contents for building and testing.