### PR TITLE
feat: number field component

### DIFF
--- a/front/src/components/NumberField/NumberField.tsx
+++ b/front/src/components/NumberField/NumberField.tsx
@@ -1,0 +1,18 @@
+import { NumberInput } from '@Front/ui/molecules/Inputs/NumberInput/NumberInput';
+import { type ComponentProps } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+type NumberInputProps = Omit<ComponentProps<typeof NumberInput>, 'error'>;
+
+export const NumberField = (props : NumberInputProps) => {
+  const { register, formState } = useFormContext();
+  const { errors } = formState;
+
+  return (
+    <NumberInput
+      {...props}
+      {...(register(props.name))}
+      error={errors[props.name]?.message as string}
+    />
+  );
+};

--- a/front/src/components/NumberField/__tests__/NumberField.test.tsx
+++ b/front/src/components/NumberField/__tests__/NumberField.test.tsx
@@ -56,7 +56,7 @@ describe('NumberField', () => {
     );
 
     const input = screen.getByLabelText('Number');
-    await userEvent.type(input, "1");
+    await userEvent.type(input, '1');
 
     expect(input).toHaveValue(1);
   });

--- a/front/src/components/NumberField/__tests__/NumberField.test.tsx
+++ b/front/src/components/NumberField/__tests__/NumberField.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+import { type ReactNode } from 'react';
+import { NumberField } from '../NumberField';
+
+const FormWrapper = ({
+  children,
+  defaultValues = {},
+}: {
+  children: ReactNode;
+  defaultValues?: Record<string, unknown>;
+}) => {
+  const methods = useForm({ defaultValues });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('NumberField', () => {
+  it('renders without crashing', () => {
+    render(
+      <FormWrapper>
+        <NumberField name="number" label="Number" />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByLabelText('Number')).toBeInTheDocument();
+    expect(screen.getByLabelText('Number')).toHaveAttribute('name', 'number');
+  });
+
+  it('displays the error message from form state when validation fails', async () => {
+    const WrapperWithError = () => {
+      const methods = useForm({ defaultValues: { number: '' } });
+
+      const { setError } = methods;
+
+      return (
+        <FormProvider {...methods}>
+          <NumberField name="number" label="Number" />
+          <button onClick={() => setError('number', { message: 'This field is required' })}>Trigger error</button>
+        </FormProvider>
+      );
+    };
+
+    render(<WrapperWithError />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Trigger error' }));
+
+    expect(await screen.findByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('updates the input value on user typing', async () => {
+    render(
+      <FormWrapper>
+        <NumberField name="number" label="Number" />
+      </FormWrapper>,
+    );
+
+    const input = screen.getByLabelText('Number');
+    await userEvent.type(input, "1");
+
+    expect(input).toHaveValue(1);
+  });
+});


### PR DESCRIPTION
**Title:** Add NumberField wrapper component

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
Closes #683

**Context:**
This adds a new `NumberField` component for the front-end form library, enabling numeric inputs to integrate with `react-hook-form` and surface validation errors through the existing `NumberInput` component.

**Proposed Changes:**
- Added `front/src/components/NumberField/NumberField.tsx` as a wrapper around `NumberInput` that registers the field with `useFormContext()`.
- Propagates `react-hook-form` validation state to the `error` prop on `NumberInput`.
- Added tests in `front/src/components/NumberField/__tests__/NumberField.test.tsx` to verify rendering, validation error display, and user input behavior.

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [x] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)