### PR TITLE
feat(front): checkbox field component

### DIFF
--- a/front/src/components/CheckboxField/CheckboxField.tsx
+++ b/front/src/components/CheckboxField/CheckboxField.tsx
@@ -1,0 +1,18 @@
+import { MonoCheckboxInput } from '@Front/ui/molecules/Inputs/MonoCheckboxInput/MonoCheckboxInput';
+import { type ComponentProps } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+type CheckboxInputProps = Omit<ComponentProps<typeof MonoCheckboxInput>, 'error'>;
+
+export const CheckboxField = (props : CheckboxInputProps) => {
+  const { register, formState } = useFormContext();
+  const { errors } = formState;
+
+  return (
+    <MonoCheckboxInput
+      {...props}
+      {...(register(props.name))}
+      error={errors[props.name]?.message as string}
+    />
+  );
+};

--- a/front/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/front/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+import { CheckboxField } from '../CheckboxField';
+import { type ReactNode } from 'react';
+
+const FormWrapper = ({
+  children,
+  defaultValues = {},
+}: {
+  children: ReactNode;
+  defaultValues?: Record<string, unknown>;
+}) => {
+  const methods = useForm({ defaultValues });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('CheckboxField', () => {
+  it('renders without crashing', () => {
+    render(
+      <FormWrapper>
+        <CheckboxField name="acceptTerms" label="Accept Terms" />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByLabelText('Accept Terms')).toBeInTheDocument();
+    expect(screen.getByLabelText('Accept Terms')).toHaveAttribute('name', 'acceptTerms');
+  });
+
+  it('displays the error message from form state when validation fails', async () => {
+    const WrapperWithError = () => {
+      const methods = useForm({ defaultValues: { acceptTerms: false } });
+
+      const { setError } = methods;
+
+      return (
+        <FormProvider {...methods}>
+          <CheckboxField name="acceptTerms" label="Accept Terms" />
+          <button onClick={() => setError('acceptTerms', { message: 'This field is required' })}>Trigger error</button>
+        </FormProvider>
+      );
+    };
+
+    render(<WrapperWithError />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Trigger error' }));
+
+    const errorMessage = await screen.findByText('This field is required');
+
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it('updates the input value on user typing', async () => {
+    render(
+      <FormWrapper>
+        <CheckboxField name="acceptTerms" label="Accept Terms" />
+      </FormWrapper>,
+    );
+
+    const checkbox = screen.getByLabelText('Accept Terms');
+    await userEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+  });
+});


### PR DESCRIPTION
**Title:** Add CheckboxField form wrapper

**Type of Pull Request:**

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation
-   [ ] Other (specify):

**Associated Issue:**
Closes #312

**Context:**
The project needs form-aware wrapper components that integrate the UI toolkit inputs with `react-hook-form` so form state, validation errors and registration are handled consistently across the app. Issue #312 requests the `CheckboxField` wrapper to keep the form toolkit consistent.

**Proposed Changes:**
- Add `CheckboxField` wrapper that connects `MonoCheckboxInput` to `react-hook-form` and surfaces validation errors.
  - New file: `front/src/components/CheckboxField/CheckboxField.tsx`
  - New tests: `front/src/components/CheckboxField/__tests__/CheckboxField.test.tsx`
- Tests cover rendering, error message propagation from form state, and basic user interaction (checking and typing).

**Checklist:**

-   [x] I have verified that my changes work as expected
-   [x] I have updated the documentation if necessary
-   [x] I have thought to rebase my branch
-   [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
Accessibility: checkboxx wrapper forward `label` correctly and surface error text; ensure parent forms use accessible labels and that focus states are preserved. Performance impact is minimal. Tests included. Dependencies: none. Risks: none notable.