### PR TITLE
fix(renovate): add gomodtidy postUpdateOption

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,9 @@
   "npm": {
     "rangeStrategy": "bump"
   },
+  "postUpdateOptions": [
+    "gomodTidyE"
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
J'ai besoin d'ajouter cette option
Avec ça il n'y devrait plus y avoir de problème sur les update des dépendances indirectes

Cela devrait régler :
- les CI qui ne passent pas sur certaines update renovate back
- le bug du lancement de l'app qui était apparu récemment du à l'update d'une dépendance automatique