### PR TITLE
fix: re-add makefile docker-deps and docker-deps-down scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,19 @@ storybook:
 	@mise install
 	@cd front && npm install
 	@echo "\n📒 Starting Storybook on http://localhost:3002"
-	@cd front && npm run start:storybook
+	cd front && npm run start:storybook
+
+# Start dockerized dependencies (host mode)
+docker-deps:
+	@echo "\n🐳 Starting dockerized dependencies..."
+	@docker compose -f docker-compose.dev.yml -f docker-compose.traefik-host.yml up -d traefik postgres
+	@echo "✅ Traefik is starting on https://localhost (dashboard: http://localhost:9000)"
+	@echo "✅ Postgres is starting on localhost:5432"
+	@echo "📝 Make sure your frontend is running on http://localhost:3000"
+	@echo "📝 Make sure your backend is running on http://localhost:3001"
+
+# Stop dockerized dependencies (host mode)
+docker-deps-down:
+	@echo "\n🐳 Stopping dockerized dependencies..."
+	@docker compose -f docker-compose.dev.yml -f docker-compose.traefik-host.yml down
+	@echo "🛑 Dependencies stopped"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ storybook:
 	@mise install
 	@cd front && npm install
 	@echo "\n📒 Starting Storybook on http://localhost:3002"
-	cd front && npm run start:storybook
+	@cd front && npm run start:storybook
 
 # Start dockerized dependencies (host mode)
 docker-deps:


### PR DESCRIPTION
La PR de mise à retiré ces deux scripts, je ne sais pourquoi (probablement un conflit mal géré ?)
Je les ai ajoutés de nouveau

Ils sont toujours utile pour le lancement de l'app sans dev-container