### PR TITLE
refactor: unify providers in customRender files

### DIFF
--- a/front/src/utils/testsUtils/customRender/TestProviders.tsx
+++ b/front/src/utils/testsUtils/customRender/TestProviders.tsx
@@ -1,0 +1,35 @@
+import { AuthenticationContextProvider } from "@Front/contexts/AuthenticationContext/AuthenticationContextProvider";
+import { LoaderProvider } from "@Front/providers/loaderProvider/LoaderProvider";
+import { ToastProvider } from "@Front/ui/utils/toast/toastProvider/ToastProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+
+export const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+      },
+    },
+  });
+
+type TestProvidersProps = PropsWithChildren<{
+  client?: QueryClient;
+}>;
+
+export const TestProviders = ({
+  children,
+  client = createQueryClient(),
+}: TestProvidersProps) => (
+  <QueryClientProvider client={client}>
+    <LoaderProvider>
+      <ToastProvider>
+        <AuthenticationContextProvider>
+          {children}
+        </AuthenticationContextProvider>
+      </ToastProvider>
+    </LoaderProvider>
+  </QueryClientProvider>
+);

--- a/front/src/utils/testsUtils/customRender/customRender.browser.tsx
+++ b/front/src/utils/testsUtils/customRender/customRender.browser.tsx
@@ -1,6 +1,4 @@
-import { AuthenticationContextProvider } from "@Front/contexts/AuthenticationContext/AuthenticationContextProvider";
 import { routeObject } from "@Front/routing/routes";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   createMemoryRouter,
   RouterProvider,
@@ -8,17 +6,7 @@ import {
   type RouteObject,
 } from "react-router";
 import { render } from "vitest-browser-react";
-
-const createQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-      },
-    },
-  });
+import { createQueryClient, TestProviders } from "./TestProviders";
 
 export type RenderBrowserRouteOptions = {
   routes?: RouteObject[];
@@ -44,10 +32,8 @@ export const renderBrowserRoute = ({
   });
 
   return render(
-    <QueryClientProvider client={createQueryClient()}>
-      <AuthenticationContextProvider>
-        <RouterProvider router={router} />
-      </AuthenticationContextProvider>
-    </QueryClientProvider>,
+    <TestProviders client={createQueryClient()}>
+      <RouterProvider router={router} />
+    </TestProviders>,
   );
 };

--- a/front/src/utils/testsUtils/customRender/customRender.tsx
+++ b/front/src/utils/testsUtils/customRender/customRender.tsx
@@ -1,7 +1,5 @@
-import { AuthenticationContextProvider } from "@Front/contexts/AuthenticationContext/AuthenticationContextProvider";
-import { LoaderProvider } from "@Front/providers/loaderProvider/LoaderProvider";
 import { routeObject } from "@Front/routing/routes";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { render, type RenderOptions } from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
 import {
@@ -10,6 +8,7 @@ import {
   type MemoryRouterOpts,
   type RouteObject,
 } from "react-router";
+import { createQueryClient, TestProviders } from "./TestProviders";
 
 export type RenderWithQueryClientOptions = {
   renderOptions?: Omit<RenderOptions, "queries">;
@@ -42,15 +41,7 @@ export const renderWithQueryClient = (
     renderOptions,
   }: RenderWithQueryClientOptions = {},
 ) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-      },
-    },
-  });
+  const queryClient = createQueryClient();
 
   return render(
     <QueryClientProvider client={queryClient} {...queryClientProviderOptions}>
@@ -67,18 +58,17 @@ export const renderRoute = ({
   renderOptions,
   queryClientProviderOptions,
 }: RenderRouteOptions) => {
-  const routesOptionsWithEntry = {
+  const router = createMemoryRouter(routes, {
     initialEntries: initialEntry ? [initialEntry] : undefined,
     ...routesOptions,
-  };
-  const router = createMemoryRouter(routes, routesOptionsWithEntry);
+  });
 
-  return renderWithQueryClient(
-    <LoaderProvider>
-      <AuthenticationContextProvider>
-        <RouterProvider router={router} />
-      </AuthenticationContextProvider>
-    </LoaderProvider>,
-    { queryClientProviderOptions, renderOptions },
+  const client = queryClientProviderOptions?.client ?? createQueryClient();
+
+  return render(
+    <TestProviders client={client}>
+      <RouterProvider router={router} />
+    </TestProviders>,
+    renderOptions,
   );
 };


### PR DESCRIPTION
**Title:** Unify providers in customRender files

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1035

**Context:**
The test utilities `customRender.tsx` (unit tests) and `customRender.browser.tsx` (browser tests) were each defining identical provider compositions (QueryClientProvider, LoaderProvider, ToastProvider, AuthenticationContextProvider). This duplication meant that any provider changes had to be made in two places, increasing maintenance burden and risk of inconsistency. The goal is to unify these providers into a single shared component to ensure consistency and reduce duplication.

**Proposed Changes:**
- Created a new `TestProviders.tsx` file containing:
  - `createQueryClient()` factory function with standardized default options
  - `TestProviders` wrapper component that composes all required providers in the correct order
- Refactored `customRender.tsx` to use the shared `TestProviders` and `createQueryClient` utilities
- Refactored `customRender.browser.tsx` to use the shared `TestProviders` and `createQueryClient` utilities
- Both files now import from the shared provider file instead of duplicating provider logic

**Checklist:**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None