### PR TITLE
fix(back): store termsAccepted value in jwt on token refresh

### DIFF
--- a/back/pkg/signin/signin.service.go
+++ b/back/pkg/signin/signin.service.go
@@ -137,9 +137,10 @@ func (s *SigninService) RefreshAccessToken(refreshTokenString string) (tokenResp
 
 	// Generate new tokens
 	claims := &guard.Claims{
-		Id:       account.Id,
-		Username: account.UserName,
-		Email:    account.Email,
+		Id:            account.Id,
+		Username:      account.UserName,
+		Email:         account.Email,
+		TermsAccepted: account.TermsAcceptedAt != nil,
 	}
 
 	return s.GenerateTokens(claims)


### PR DESCRIPTION
`TermsAccepted` n'était pas présent dans le jwt lors d'un refresh de token
Ce qui causait une erreur de "Termes non accepté" alors que c'était pourtant le cas pour l'utilisateur