### PR TITLE
chore(back): ignore not found repo errors on find methods

### DIFF
--- a/back/db/db.go
+++ b/back/db/db.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 var conn *gorm.DB
@@ -17,7 +18,9 @@ func Init() *gorm.DB {
 	conn, err = gorm.Open(postgres.New(postgres.Config{
 		DSN:                  c.Db.GetPostgresConnectionInfo(),
 		PreferSimpleProtocol: true,
-	}), &gorm.Config{})
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
 
 	if err != nil {
 		log.Error().Err(err).Msg("failed to connect to database")

--- a/back/db/repository/account.repo.go
+++ b/back/db/repository/account.repo.go
@@ -85,7 +85,9 @@ func (*AccountRepository) Updates(account model.Account) error {
 
 func (*AccountRepository) FindOneById(id uuid.UUID, account *model.Account) error {
 	if err := db.GetDB().Where("id = ? AND deleted_at IS NULL", id.String()).Preload("Providers").First(&account).Error; err != nil {
-		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_ID Failed to find account by id")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_ID Failed to find account by id")
+		}
 		return err
 	}
 	return nil
@@ -99,7 +101,9 @@ func (*AccountRepository) FindOneByUsername(username string, account *model.Acco
 	}
 
 	if err := query.Preload("Providers").First(&account).Error; err != nil {
-		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_USERNAME Failed to find account by username")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_USERNAME Failed to find account by username")
+		}
 		return err
 	}
 	return nil
@@ -107,7 +111,9 @@ func (*AccountRepository) FindOneByUsername(username string, account *model.Acco
 
 func (*AccountRepository) FindOneByEmail(email string, account *model.Account) error {
 	if err := db.GetDB().Where("LOWER(email) = LOWER(?) AND deleted_at IS NULL", email).Preload("Providers").First(&account).Error; err != nil {
-		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_EMAIL Failed to find account by email")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_EMAIL Failed to find account by email")
+		}
 		return err
 	}
 	return nil
@@ -115,7 +121,9 @@ func (*AccountRepository) FindOneByEmail(email string, account *model.Account) e
 
 func (*AccountRepository) FindOneByEmailOrUsername(emailOrUsername string, account *model.Account) error {
 	if err := db.GetDB().Where("(LOWER(email) = LOWER(?) OR LOWER(username) = LOWER(?)) AND deleted_at IS NULL", emailOrUsername, emailOrUsername).Preload("Providers").First(&account).Error; err != nil {
-		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_EMAIL_OR_USERNAME Failed to find account by email or username")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_EMAIL_OR_USERNAME Failed to find account by email or username")
+		}
 		return err
 	}
 	return nil
@@ -123,7 +131,9 @@ func (*AccountRepository) FindOneByEmailOrUsername(emailOrUsername string, accou
 
 func (*AccountRepository) FindOneByResetToken(resetToken string, account *model.Account) error {
 	if err := db.GetDB().Where("reset_token = ? AND deleted_at IS NULL", resetToken).Preload("Providers").First(&account).Error; err != nil {
-		log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_RESET_TOKEN Failed to find account by reset token")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("ACCOUNT_REPOSITORY::FIND_ONE_BY_RESET_TOKEN Failed to find account by reset token")
+		}
 		return err
 	}
 	return nil

--- a/back/db/repository/account_event.repo.go
+++ b/back/db/repository/account_event.repo.go
@@ -3,9 +3,11 @@ package repository
 import (
 	"app/db"
 	model "app/db/models"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -35,7 +37,9 @@ func (*AccountEventRepository) Updates(accountEvent *model.AccountEvent) error {
 
 func (*AccountEventRepository) FindByAccountAndEventId(accountId, eventId uuid.UUID, accountEvent *model.AccountEvent) error {
 	if err := db.GetDB().Where("account_id = ? AND event_id = ?", accountId, eventId).Preload("Account").First(&accountEvent).Error; err != nil {
-		log.Error().Err(err).Msg("ACCOUNT_EVENT_REPOSITORY::FIND_BY_ACCOUNT_AND_EVENT_ID Failed to find account_event")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("ACCOUNT_EVENT_REPOSITORY::FIND_BY_ACCOUNT_AND_EVENT_ID Failed to find account_event")
+		}
 		return err
 	}
 

--- a/back/db/repository/account_providers.repo.go
+++ b/back/db/repository/account_providers.repo.go
@@ -3,8 +3,10 @@ package repository
 import (
 	"app/db"
 	model "app/db/models"
+	"errors"
 
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
 )
 
 type AccountProvidersRepository struct{}
@@ -27,7 +29,7 @@ func (*AccountProvidersRepository) Create(accountProvider model.AccountProvider)
 
 func (*AccountProvidersRepository) FindOneById(id string, provider string, accountProvider *model.AccountProvider) error {
 	err := db.GetDB().Where("LOWER(provider) = LOWER(?) AND LOWER(id) = LOWER(?)", provider, id).Preload("Account").First(&accountProvider).Error
-	if err != nil {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		log.Error().Err(err).Msg("ACCOUNT_PROVIDERS_REPOSITORY::FIND_ONE_BY_ID Failed to find account provider")
 	}
 	return err

--- a/back/db/repository/availability.repo.go
+++ b/back/db/repository/availability.repo.go
@@ -72,7 +72,9 @@ func (r *AvailabilityRepository) FindOneById(id uuid.UUID, availability *model.A
 	}
 
 	if err := r.db.Preload("Account").Preload("Event").Preload("Event.AccountEvents").First(&availability, "id = ?", id).Error; err != nil {
-		log.Error().Err(err).Msg("AVAILABILITY_REPOSITORY::FIND_ONE_BY_ID Failed to find availability by ID")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("AVAILABILITY_REPOSITORY::FIND_ONE_BY_ID Failed to find availability by ID")
+		}
 		return err
 	}
 
@@ -115,7 +117,9 @@ func (r *AvailabilityRepository) Update(availability *model.Availability) error 
 	}
 
 	if err := r.db.Preload("Account").Preload("Event").Preload("Event.AccountEvents").First(&availability, "id = ?", availability.Id).Error; err != nil {
-		log.Error().Err(err).Msg("AVAILABILITY_REPOSITORY::UPDATE Failed to reload availability after update")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Msg("AVAILABILITY_REPOSITORY::UPDATE Failed to reload availability after update")
+		}
 		return err
 	}
 

--- a/back/db/repository/slot.repo.go
+++ b/back/db/repository/slot.repo.go
@@ -3,9 +3,11 @@ package repository
 import (
 	"app/db"
 	model "app/db/models"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -31,7 +33,9 @@ func (*SlotRepository) Updates(slot *model.Slot) error {
 
 func (*SlotRepository) FindOneById(slotId uuid.UUID, slot *model.Slot) error {
 	if err := db.GetDB().Where("id = ?", slotId.String()).Preload("Event").Preload("Event.Owner").Preload("Event.AccountEvents").Preload("Event.AccountEvents.Account").First(slot).Error; err != nil {
-		log.Error().Err(err).Str("slotId", slotId.String()).Msg("SLOT_REPOSITORY::FIND_ONE_BY_ID Failed to find slot by id")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Error().Err(err).Str("slotId", slotId.String()).Msg("SLOT_REPOSITORY::FIND_ONE_BY_ID Failed to find slot by id")
+		}
 		return err
 	}
 


### PR DESCRIPTION
- Suppression de logs GORM par défaut, en double avec notre logger
- Notre logger dans les repository n'affiche plus les erreurs de type `not found` lors de récupération de donnée, inutile dans le cas où le but est de vérifier qu'il n'y a pas de donnée (ex : email non existant sur les accounts)