### PR TITLE
chore(back): remove hard coded db timezone

### DIFF
--- a/back/.env.model
+++ b/back/.env.model
@@ -12,6 +12,7 @@ DB_PORT=5432
 DB_USER=slotfinder
 DB_PASSWORD=slotfinder
 DB_NAME=slotfinder
+DB_TIMEZONE=Europe/Paris
 
 ENCRYPTION_KEY=
 

--- a/back/config/config_db.go
+++ b/back/config/config_db.go
@@ -12,6 +12,7 @@ type DbConfiguration struct {
 	User     string `env:"DB_USER"`
 	Password string `env:"DB_PASSWORD"`
 	Name     string `env:"DB_NAME"`
+	TimeZone string `env:"DB_TIMEZONE"`
 }
 
 // Dialect returns "postgres"
@@ -21,14 +22,19 @@ func (c DbConfiguration) Dialect() string {
 
 // GetPostgresConnectionInfo returns Postgres URL string
 func (c DbConfiguration) GetPostgresConnectionInfo() string {
+	timezone := c.TimeZone
+	if timezone == "" {
+		timezone = "UTC" // Default to UTC if not specified
+	}
+
 	if c.Password == "" {
 		return fmt.Sprintf(
-			"host=%s port=%d user=%s dbname=%s sslmode=disable",
-			c.Host, c.Port, c.User, c.Name)
+			"host=%s port=%d user=%s dbname=%s sslmode=disable TimeZone=%s",
+			c.Host, c.Port, c.User, c.Name, timezone)
 	}
 	return fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable TimeZone=%s",
-		c.Host, c.Port, c.User, c.Password, c.Name, "Europe/Paris")
+		c.Host, c.Port, c.User, c.Password, c.Name, timezone)
 }
 
 // GetPostgresConfig returns PostgresConfig object
@@ -44,5 +50,6 @@ func GetPostgresConfig() DbConfiguration {
 		User:     os.Getenv("DB_USER"),
 		Password: os.Getenv("DB_PASSWORD"),
 		Name:     os.Getenv("DB_NAME"),
+		TimeZone: os.Getenv("DB_TIMEZONE"),
 	}
 }


### PR DESCRIPTION
Retire la timezone hard codé de base de donnée
Rappel : n'affecte en rien le fonctionnement de l'app, ce n'est que de l'affichage dans le cas de date sans timezone