### PR TITLE
ci: include renovate co author in deploy prevention

### DIFF
--- a/.github/workflows/develop-pipeline.yml
+++ b/.github/workflows/develop-pipeline.yml
@@ -38,7 +38,9 @@ jobs:
   build-staging:
     name: Build Staging Images
     needs: [back-ci, front-ci, docker-ci]
-    if: github.actor != 'renovate[bot]'
+    if: >-
+      github.actor != 'renovate[bot]' &&
+      !contains(github.event.head_commit.message, 'Co-authored-by: renovate[bot]')
     runs-on: self-hosted
     timeout-minutes: 20
     steps:
@@ -63,7 +65,9 @@ jobs:
   deploy-staging:
     name: Deploy to Staging
     needs: build-staging
-    if: github.actor != 'renovate[bot]'
+    if: >-
+      github.actor != 'renovate[bot]' &&
+      !contains(github.event.head_commit.message, 'Co-authored-by: renovate[bot]')
     runs-on: self-hosted
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Je sais pas si le nom de la pr est correcte

---

J'ai ajouté la description de commit dans la condition pour ignorer le build & deploy, qui prenait en compte les commit mergés par nous alors qu'ils proviennent de pr renovate

Il n'y avait pas de souci sur les auto merge de renovate