### PR TITLE
feat: add CardPage component

### DIFF
--- a/.github/workflows/front-build.yaml
+++ b/.github/workflows/front-build.yaml
@@ -12,10 +12,10 @@ on:
   workflow_call:
     inputs:
       base_ref:
-        description: 'Base SHA for change detection (used when called via workflow_call)'
+        description: "Base SHA for change detection (used when called via workflow_call)"
         type: string
         required: false
-        default: ''
+        default: ""
 
 permissions:
   contents: read
@@ -147,7 +147,7 @@ jobs:
   chromatic:
     name: Run Chromatic
     needs: [detect-changes, install]
-    if: needs.detect-changes.outputs.front == 'true' && ((github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') || ((github.event_name == 'push' || github.event_name == 'workflow_call') && github.ref == 'refs/heads/main'))
+    if: needs.detect-changes.outputs.front == 'true' && ((github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop') || ((github.event_name == 'push' || github.event_name == 'workflow_call') && github.ref == 'refs/heads/develop'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/front/src/components/CardPage/CardPage.scss
+++ b/front/src/components/CardPage/CardPage.scss
@@ -1,0 +1,32 @@
+@use "../../utils/sass/mixins/responsive";
+@use "../../utils/sass/mixins/helpers";
+
+.card-page {
+  --card-page-margin-top: #{helpers.px-to-rem(16)};
+  --card-page-row-gap: #{helpers.px-to-rem(16)};
+
+  display: flex;
+  box-sizing: border-box;
+  min-height: 100vh;
+  min-height: 100dvh;
+  margin-top: var(--card-page-margin-top);
+  margin-bottom: helpers.px-to-rem(16);
+  flex-direction: column;
+  justify-content: center;
+  row-gap: var(--card-page-row-gap);
+
+  @include responsive.media-exceeds-width("tablet") {
+    --cols: 6;
+    --start: 2;
+  }
+
+  @include responsive.media-exceeds-width("desktop-small") {
+    --start: 4;
+    --card-page-row-gap: #{helpers.px-to-rem(24)};
+    --card-page-margin-top: #{helpers.px-to-rem(32)};
+  }
+
+  &__title {
+    text-align: center;
+  }
+}

--- a/front/src/components/CardPage/CardPage.tsx
+++ b/front/src/components/CardPage/CardPage.tsx
@@ -1,0 +1,34 @@
+import { Card } from "@Front/ui/atoms/Card/Card";
+import { Heading } from "@Front/ui/atoms/Heading/Heading";
+import { getClassName } from "@Front/utils/getClassName";
+import type { ComponentProps, ReactNode } from "react";
+
+import "./CardPage.scss";
+
+type CardProps = {
+  title: ReactNode;
+  children: ReactNode;
+} & ComponentProps<"section">;
+
+const defaultClassName = "card-page";
+
+export const CardPage = ({
+  title,
+  className,
+  children,
+  ...props
+}: CardProps) => {
+  const parentClassName = getClassName({
+    defaultClassName,
+    className,
+  });
+
+  return (
+    <section className={parentClassName} {...props}>
+      <Heading level={1} className={`${defaultClassName}__title`}>
+        {title}
+      </Heading>
+      <Card borderWeight="bold">{children}</Card>
+    </section>
+  );
+};

--- a/front/src/components/CardPage/__tests__/CardPage.test.tsx
+++ b/front/src/components/CardPage/__tests__/CardPage.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+
+import { CardPage } from "../CardPage";
+
+describe("CardPage", () => {
+  it("should render title as level 1 heading and children", () => {
+    render(
+      <CardPage title="Authentication">
+        <p>Form content</p>
+      </CardPage>,
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Authentication" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Form content")).toBeInTheDocument();
+  });
+
+  it("should apply default and custom class names on section", () => {
+    render(
+      <CardPage title="Title" className="custom-class" data-testid="card-page">
+        <span>Child</span>
+      </CardPage>,
+    );
+
+    expect(screen.getByTestId("card-page")).toHaveClass(
+      "card-page",
+      "custom-class",
+    );
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Title" }),
+    ).toHaveClass("card-page__title");
+  });
+
+  it("should render children inside a bold Card wrapper", () => {
+    render(
+      <CardPage title="Title">
+        <span>Child content</span>
+      </CardPage>,
+    );
+
+    const cardContainer = screen.getByText("Child content").closest(".ds-card");
+    expect(cardContainer).toBeInTheDocument();
+    expect(cardContainer).toHaveClass("ds-card--bold");
+  });
+});

--- a/front/src/ui/atoms/Card/Card.mdx
+++ b/front/src/ui/atoms/Card/Card.mdx
@@ -17,6 +17,10 @@ A reusable, accessible card atom for displaying content.
 <Card className="custom-class">
   Card content with custom class
 </Card>
+
+<Card borderWeight="bold">
+  Card content with bold border
+</Card>
 ```
 
 ## Props
@@ -50,6 +54,18 @@ A reusable, accessible card atom for displaying content.
       </td>
       <td>No</td>
       <td>Custom class for styling</td>
+    </tr>
+    <tr>
+      <td>
+        <code>borderWeight</code>
+      </td>
+      <td>
+        <code>"default" | "bold"</code>
+      </td>
+      <td>No</td>
+      <td>
+        Controls card border thickness. Defaults to <code>"default"</code>
+      </td>
     </tr>
     <tr>
       <td>
@@ -89,6 +105,10 @@ A reusable, accessible card atom for displaying content.
 
 <Card className="custom-class">
   Card content with custom class
+</Card>
+
+<Card borderWeight="bold">
+  Card content with bold border
 </Card>
 
 ```

--- a/front/src/ui/atoms/Card/Card.scss
+++ b/front/src/ui/atoms/Card/Card.scss
@@ -1,10 +1,13 @@
 @use "../../../utils/sass/mixins/helpers";
 
 .ds-card {
-  width: 100%;
   height: fit-content;
   padding: helpers.px-to-rem(16px);
   border: 1px solid var(--color-black);
   border-radius: helpers.px-to-rem(8px);
   background-color: var(--card-color-background);
+
+  &--bold {
+    border-width: 2px;
+  }
 }

--- a/front/src/ui/atoms/Card/Card.stories.tsx
+++ b/front/src/ui/atoms/Card/Card.stories.tsx
@@ -8,10 +8,15 @@ const meta = {
   args: {
     children: "Card",
     className: "custom-class",
+    borderWeight: "default",
   },
   argTypes: {
     children: {
       control: { type: "text" },
+    },
+    borderWeight: {
+      control: { type: "radio" },
+      options: ["default", "bold"],
     },
   },
   decorators: [
@@ -27,8 +32,10 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Default: Story = {};
+
+export const Bold: Story = {
   args: {
-    children: "Card",
+    borderWeight: "bold",
   },
 };

--- a/front/src/ui/atoms/Card/Card.tsx
+++ b/front/src/ui/atoms/Card/Card.tsx
@@ -4,11 +4,13 @@ import "./Card.scss";
 
 type CardProps<As extends ElementType = "div"> = {
   as?: As;
+  borderWeight?: "default" | "bold";
 } & ComponentPropsWithoutRef<As>;
 
 export const Card = <As extends ElementType = "div">({
   as,
   className,
+  borderWeight = "default",
   children,
   ...props
 }: CardProps<As>) => {
@@ -17,6 +19,7 @@ export const Card = <As extends ElementType = "div">({
   const parentClassName = getClassName({
     defaultClassName: "ds-card",
     className,
+    modifiers: [borderWeight !== "default" && borderWeight],
   });
 
   return (

--- a/front/src/ui/atoms/Card/__tests__/Card.test.tsx
+++ b/front/src/ui/atoms/Card/__tests__/Card.test.tsx
@@ -4,21 +4,32 @@ import { Card } from "../Card";
 describe("Card", () => {
   it("renders children", () => {
     render(<Card>Card</Card>);
+
     expect(screen.getByText("Card")).toBeInTheDocument();
   });
 
   it("applies additional class names", () => {
     render(<Card className="custom-class">Card</Card>);
+
+    expect(screen.getByText("Card")).toHaveClass("ds-card");
     expect(screen.getByText("Card")).toHaveClass("custom-class");
   });
 
   it('renders as a different element when "as" prop is provided', () => {
     render(<Card as="section">Card</Card>);
+
     expect(screen.getByText("Card").tagName).toBe("SECTION");
   });
 
   it("renders with div by default", () => {
     render(<Card>Card</Card>);
+
     expect(screen.getByText("Card").tagName).toBe("DIV");
+  });
+
+  it("applies border weight class when borderWeight prop is provided", () => {
+    render(<Card borderWeight="bold">Card</Card>);
+
+    expect(screen.getByText("Card")).toHaveClass("ds-card--bold");
   });
 });

--- a/front/src/ui/atoms/Heading/Heading.scss
+++ b/front/src/ui/atoms/Heading/Heading.scss
@@ -1,11 +1,30 @@
-h1 {
-  font-size: 2rem;
-}
+@use "../../../utils/sass/mixins/responsive";
+@use "../../../utils/sass/mixins/helpers";
 
-h2 {
-  font-size: 1.5rem;
-}
+.ds-heading {
+  --ds-heading-font-size: #{helpers.px-to-rem(16)};
 
-h3 {
-  font-size: 1.25rem;
+  font-size: var(--ds-heading-font-size);
+
+  &:where(h1) {
+    --ds-heading-font-size: #{helpers.px-to-rem(24)};
+
+    @include responsive.media-exceeds-width("tablet") {
+      --ds-heading-font-size: #{helpers.px-to-rem(32)};
+    }
+  }
+
+  &:where(h2) {
+    --ds-heading-font-size: #{helpers.px-to-rem(20)};
+
+    @include responsive.media-exceeds-width("tablet") {
+      --ds-heading-font-size: #{helpers.px-to-rem(24)};
+    }
+  }
+
+  &:where(h3) {
+    @include responsive.media-exceeds-width("tablet") {
+      --ds-heading-font-size: #{helpers.px-to-rem(20)};
+    }
+  }
 }

--- a/front/src/ui/organisms/Popover/Popover.scss
+++ b/front/src/ui/organisms/Popover/Popover.scss
@@ -16,6 +16,7 @@
   inset-block: auto 0;
   display: revert;
   box-sizing: border-box;
+  margin-inline-start: 5px;
 
   &:popover-open {
     display: flex;


### PR DESCRIPTION
**Title:** Add CardPage component

**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #313

**Context:**
This change introduces a reusable `CardPage` component to serve as a page scaffold with a title and card-based content area. It also includes supporting front-end cleanup and layout updates needed for this page pattern to work consistently.

**Proposed Changes:**
- Added a new `CardPage` component that renders a semantic page section with an `h1` title and a bold `Card` wrapper for page content.
- Added dedicated styles for the page layout, including responsive spacing and grid positioning.
- Added tests covering heading rendering, class name composition, and card wrapping behavior.
- Wired the grid stylesheet into the shared CSS entrypoint and included related frontend layout/style updates needed by the new page structure.
- Updated adjacent card, heading, layout, authentication, and popover styles as part of the supporting cleanup.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
This branch depends on #1132 and should be merged after that PR is landed. The layout changes affect responsive page structure, so visual regression checks are recommended.

Result : 

<img width="1860" height="944" alt="Recording 2026-07-13 at 11 43 27" src="https://github.com/user-attachments/assets/6e27309b-5445-4b8d-81f9-fcb501dd572c" />
