### PR TITLE
fix(ci): correct output variable name for front storybook changes

### DIFF
--- a/.github/workflows/front-build.yaml
+++ b/.github/workflows/front-build.yaml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       front-changes: ${{ steps.filter.outputs.front }}
-      front-storybook-changes: ${{ steps.filter.outputs.front_storybook }}
+      front-storybook-changes: ${{ steps.filter.outputs.front-storybook }}
       back-changes: ${{ steps.filter.outputs.back }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This pull request makes a minor update to the workflow outputs in `.github/workflows/front-build.yaml`, correcting the output variable name for front-end Storybook changes to use a hyphen instead of an underscore.