### PR TITLE
feat(oxlint): add function component definition rule

### DIFF
--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -7,6 +7,13 @@
   },
   "plugins": ["react", "typescript", "import", "jsx-a11y", "vitest"],
   "rules": {
+    "react/function-component-definition": [
+      "warn",
+      {
+        "namedComponents": "arrow-function",
+        "unnamedComponents": "arrow-function"
+      }
+    ],
     "react/jsx-key": "error",
     "react/jsx-max-depth": [
       "warn",

--- a/front/src/components/Layout/Header/__tests__/Header.test.tsx
+++ b/front/src/components/Layout/Header/__tests__/Header.test.tsx
@@ -56,6 +56,7 @@ describe("Header", () => {
     beforeEach(() => {
       server.use(getAuthStatus200);
     });
+
     it("should render the header banner", async () => {
       renderLayoutRoute("/withHeader");
 

--- a/front/src/components/fields/SelectField/__tests__/SelectField.test.tsx
+++ b/front/src/components/fields/SelectField/__tests__/SelectField.test.tsx
@@ -20,6 +20,7 @@ describe("SelectField", () => {
     { value: "male", label: "Male" },
     { value: "female", label: "Female" },
   ];
+
   it("renders without crashing", () => {
     render(
       <FormWrapper>


### PR DESCRIPTION
Introduce a new rule for function component definitions to enforce the use of arrow functions for both named and unnamed components.